### PR TITLE
Remove EventHandlerManager from scene graph elements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ ext.java9Args = [
         "--add-exports=javafx.controls/com.sun.javafx.scene.control=org.controlsfx.controls",
         // For InputMap used in behavior classes
         "--add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=org.controlsfx.controls",
-        // For EventHandlerManager across files
+        // For EventHandlerManager in AutoCompletionBinding
         "--add-exports=javafx.base/com.sun.javafx.event=org.controlsfx.controls",
         // For MappingChange, NonIterableChange across files
         "--add-exports=javafx.base/com.sun.javafx.collections=org.controlsfx.controls",

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/AutoCompletePopup.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/AutoCompletePopup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2017, ControlsFX
+ * Copyright (c) 2014, 2019, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,6 @@
  */
 package impl.org.controlsfx.skin;
 
-
-import com.sun.javafx.event.EventHandlerManager;
 import java.util.UUID;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
@@ -36,7 +34,6 @@ import javafx.beans.property.SimpleIntegerProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.event.Event;
-import javafx.event.EventDispatchChain;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.Node;
@@ -189,15 +186,13 @@ public class AutoCompletePopup<T> extends PopupControl{
      **************************************************************************/
 
 
-    private final EventHandlerManager eventHandlerManager = new EventHandlerManager(this);
-
     public final ObjectProperty<EventHandler<SuggestionEvent<T>>> onSuggestionProperty() { return onSuggestion; }
     public final void setOnSuggestion(EventHandler<SuggestionEvent<T>> value) { onSuggestionProperty().set(value); }
     public final EventHandler<SuggestionEvent<T>> getOnSuggestion() { return onSuggestionProperty().get(); }
     private ObjectProperty<EventHandler<SuggestionEvent<T>>> onSuggestion = new ObjectPropertyBase<EventHandler<SuggestionEvent<T>>>() {
         @SuppressWarnings({ "rawtypes", "unchecked" })
         @Override protected void invalidated() {
-            eventHandlerManager.setEventHandler(SuggestionEvent.SUGGESTION, (EventHandler<SuggestionEvent>)(Object)get());
+            setEventHandler(SuggestionEvent.SUGGESTION, (EventHandler<SuggestionEvent>)(Object)get());
         }
 
         @Override
@@ -210,12 +205,6 @@ public class AutoCompletePopup<T> extends PopupControl{
             return "onSuggestion"; //$NON-NLS-1$
         }
     };
-
-    /**{@inheritDoc}*/
-    @Override public EventDispatchChain buildEventDispatchChain(EventDispatchChain tail) {
-        return super.buildEventDispatchChain(tail).append(eventHandlerManager);
-    } 
-
 
     /***************************************************************************
      *                                                                         *

--- a/controlsfx/src/main/java/org/controlsfx/control/BreadCrumbBar.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/BreadCrumbBar.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2015, ControlsFX
+ * Copyright (c) 2014, 2019, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,7 +34,6 @@ import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.event.Event;
-import javafx.event.EventDispatchChain;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.control.Button;
@@ -42,7 +41,6 @@ import javafx.scene.control.Skin;
 import javafx.scene.control.TreeItem;
 import javafx.util.Callback;
 
-import com.sun.javafx.event.EventHandlerManager;
 import java.util.UUID;
 
 /**
@@ -57,9 +55,6 @@ import java.util.UUID;
  * </center>
  */
 public class BreadCrumbBar<T> extends ControlsFXControl {
-
-    private final EventHandlerManager eventHandlerManager = new EventHandlerManager(this);
-
 
     /**
      * Represents an Event which is fired when a bread crumb was activated.
@@ -161,21 +156,7 @@ public class BreadCrumbBar<T> extends ControlsFXControl {
         setSelectedCrumb(selectedCrumb);
         setCrumbFactory(defaultCrumbNodeFactory);
     }
-    
-    
-    
-    /***************************************************************************
-     *                                                                         *
-     * Public API                                                              *
-     *                                                                         *
-     **************************************************************************/
 
-    /** {@inheritDoc} */
-    @Override public EventDispatchChain buildEventDispatchChain(EventDispatchChain tail) {
-        return tail.prepend(eventHandlerManager);
-    }
-    
-    
     
     /***************************************************************************
      *                                                                         *
@@ -309,7 +290,7 @@ public class BreadCrumbBar<T> extends ControlsFXControl {
     private ObjectProperty<EventHandler<BreadCrumbActionEvent<T>>> onCrumbAction = new ObjectPropertyBase<EventHandler<BreadCrumbBar.BreadCrumbActionEvent<T>>>() {
         @SuppressWarnings({ "rawtypes", "unchecked" })
         @Override protected void invalidated() {
-            eventHandlerManager.setEventHandler(BreadCrumbActionEvent.CRUMB_ACTION, (EventHandler<BreadCrumbActionEvent>)(Object)get());
+            setEventHandler(BreadCrumbActionEvent.CRUMB_ACTION, (EventHandler<BreadCrumbActionEvent>)(Object)get());
         }
 
         @Override

--- a/controlsfx/src/main/java/org/controlsfx/control/HyperlinkLabel.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/HyperlinkLabel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2015, ControlsFX
+ * Copyright (c) 2013, 2019, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,8 +36,6 @@ import javafx.event.EventHandler;
 import javafx.event.EventTarget;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Skin;
-
-import com.sun.javafx.event.EventHandlerManager;
 
 /**
  * A UI control that will convert the given text into a series of text labels
@@ -96,10 +94,7 @@ public class HyperlinkLabel extends ControlsFXControl implements EventTarget {
      * 
      **************************************************************************/
     
-    private final EventHandlerManager eventHandlerManager =
-            new EventHandlerManager(this);
-    
-    
+
     
     /***************************************************************************
      * 
@@ -183,7 +178,7 @@ public class HyperlinkLabel extends ControlsFXControl implements EventTarget {
         if (onAction == null) {
             onAction = new SimpleObjectProperty<EventHandler<ActionEvent>>(this, "onAction") { //$NON-NLS-1$
                 @Override protected void invalidated() {
-                    eventHandlerManager.setEventHandler(ActionEvent.ACTION, get());
+                    setEventHandler(ActionEvent.ACTION, get());
                 }
             };
         }
@@ -206,6 +201,4 @@ public class HyperlinkLabel extends ControlsFXControl implements EventTarget {
     public final EventHandler<ActionEvent> getOnAction() {
         return onAction == null ? null : onAction.get();
     }
-
-    
 }


### PR DESCRIPTION
This PR removes unnecessary use of `EventHandlerManager` from controls which already have exposed `setEventHandler`/ `addEventHandler` methods in them.