### PR TITLE
Fix style of ContextMenu after applying decoration

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/decoration/Decorator.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/decoration/Decorator.java
@@ -195,7 +195,8 @@ public class Decorator {
                 if (_pane == null) {
                     currentlyInstallingScenes.add(scene);
                     _pane = new DecorationPane();
-                    Node oldRoot = scene.getRoot();
+                    Parent oldRoot = scene.getRoot();
+                    _pane.getStylesheets().addAll(oldRoot.getStylesheets());
                     ImplUtils.injectAsRootPane(scene, _pane, true);
                     _pane.setRoot(oldRoot);
                     currentlyInstallingScenes.remove(scene);


### PR DESCRIPTION
User-defined stylesheets for context menus do not work anymore after applying a decoration using `Decorator.addDecoration(...)`.

The Decorator applies a `DecorationPane` as root element in the scene graph but does not apply the stylesheets from the old root. While this works fine for most nodes, it does not work on user defined context menus. The context menus seem to only recognize the stylesheets of the root element.

I was only able to reproduce this issue when the nodes of the UI were loaded from an FXML file. When the nodes were defined in Java code, it worked fine.

This fix reads the stylesheets from the old root and applies them to the new `DecorationPane`.

The attached zip file cotains a sample project that reproduces this issue. The red button has a context menu with green background. If the button "Enable validation" is clicked, a validator will be attached to the text field. However, the context menu of the red button then loses it's custom style.

 The example can be run using `mvn compile exec:java`.

[sample.zip](https://github.com/controlsfx/controlsfx/files/2925838/sample.zip)
