### PR TITLE
Changes to PropertySheet

### DIFF
--- a/controlsfx-samples/src/main/java/org/controlsfx/samples/HelloPropertySheet.java
+++ b/controlsfx-samples/src/main/java/org/controlsfx/samples/HelloPropertySheet.java
@@ -64,17 +64,17 @@ public class HelloPropertySheet extends ControlsFXSample {
     private static Map<String, Object> customDataMap = new LinkedHashMap<>();
 
     static {
-        customDataMap.put("1. Name#First Name", "Jonathan");
-        customDataMap.put("1. Name#Last Name", "Giles");
-        customDataMap.put("1. Name#Birthday", LocalDate.of(1985, Month.JANUARY, 12));
-        customDataMap.put("2. Billing Address#Address 1", "");
-        customDataMap.put("2. Billing Address#Address 2", "");
-        customDataMap.put("2. Billing Address#City", "");
-        customDataMap.put("2. Billing Address#State", "");
-        customDataMap.put("2. Billing Address#Zip", "");
-        customDataMap.put("3. Phone#Home", "123-123-1234");
-        customDataMap.put("3. Phone#Mobile", "234-234-2345");
-        customDataMap.put("3. Phone#Work", "");
+        customDataMap.put("Name#First Name", "Jonathan");
+        customDataMap.put("Name#Last Name", "Giles");
+        customDataMap.put("Name#Birthday", LocalDate.of(1985, Month.JANUARY, 12));
+        customDataMap.put("Billing Address#Address 1", "");
+        customDataMap.put("Billing Address#Address 2", "");
+        customDataMap.put("Billing Address#City", "");
+        customDataMap.put("Billing Address#State", "");
+        customDataMap.put("Billing Address#Zip", "");
+        customDataMap.put("Phone#Home", "123-123-1234");
+        customDataMap.put("Phone#Mobile", "234-234-2345");
+        customDataMap.put("Phone#Work", "");
     }
 
     private PropertySheet propertySheet = new PropertySheet();
@@ -152,6 +152,10 @@ public class HelloPropertySheet extends ControlsFXSample {
             return Optional.empty();
         }
 
+        @Override
+        public int compareTo(Item o) {
+            return name.compareTo(o.getName());
+        }
     }
 
     class ActionShowInPropertySheet extends Action {

--- a/controlsfx/src/main/java/org/controlsfx/control/PropertySheet.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PropertySheet.java
@@ -125,7 +125,7 @@ public class PropertySheet extends ControlsFXControl {
      * 
      * @see PropertySheet
      */
-    public static interface Item {
+    public static interface Item extends Comparable<Item> {
         
         /**
          * Returns the class type of the property.

--- a/controlsfx/src/main/java/org/controlsfx/control/PropertySheet.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PropertySheet.java
@@ -103,9 +103,8 @@ public class PropertySheet extends ControlsFXControl {
      */
     public static enum Mode {
         /**
-         * Simply displays the properties in the 
-         * {@link PropertySheet#getItems() items list} in the order they are 
-         * in the list. 
+         * Displays the properties in the
+         * {@link PropertySheet#getItems() items list} in alphabetical order
          */
         NAME,
         

--- a/controlsfx/src/main/java/org/controlsfx/property/BeanProperty.java
+++ b/controlsfx/src/main/java/org/controlsfx/property/BeanProperty.java
@@ -205,4 +205,9 @@ public class BeanProperty implements PropertySheet.Item {
             // ignore it...
         }
     }
+
+    @Override
+    public int compareTo(Item o) {
+        return getName().compareTo(o.getName());
+    }
 }


### PR DESCRIPTION
Hi!

So PropertySheet comes with these 2 buttons that allows you to sort properties "By name" and "By category". However, the "By name" button does not sort "By name" as the name would imply, but simply sort by insertion order into the PropertySheet.

I decided to change it. First I made PropertySheet.Item extend Comparable. Then, in PropertySheetSkin, I added a case for when the mode is changed to NAME in which the PropertySheet.Item list is copied and sorted alphabetically using Collections.Sort().

My changes caused HelloPropertySheet and BeanProperty to not compile, so I added fixes to them. FYI, I have no idea what the BeanProperty thing is, I hope the fix I added is OK. I've heard of beans and I know they come from some framework I've never used, but sadly I do not know what to do with them.

Furthermore, I thought it would be nice to know which category the property comes from when in the "By name" view. So I added a second label which displays the category of the property. This is probably a matter of taste, personally I like it, but if you guys don't feel free to remove it.

That's pretty much all I've done.

Ps. I know my account might seem like a troll account because it's completely new. I promise it's not. I'm a loyal Bitbucket user and I only made this account last month for a school project. Since it's my first time contributing to a open source project I assumed you had to use the same repo-host as the project. As I'm writing this last sentence I am realising that that might not be the case, and I could've probably used my Bitbucket account. RIP me I guess.