### PR TITLE
TaskProgressView - new flag to retain tasks when succeeded, cancelled or failed

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
@@ -62,6 +62,8 @@ import javafx.util.Callback;
  */
 public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
 
+    private boolean retainTaskMode = false;
+
     /**
      * Constructs a new task progress view.
      */
@@ -69,13 +71,15 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
         getStyleClass().add("task-progress-view");
 
         EventHandler<WorkerStateEvent> taskHandler = evt -> {
-            if (evt.getEventType().equals(
-                    WorkerStateEvent.WORKER_STATE_SUCCEEDED)
-                    || evt.getEventType().equals(
-                            WorkerStateEvent.WORKER_STATE_CANCELLED)
-                    || evt.getEventType().equals(
-                            WorkerStateEvent.WORKER_STATE_FAILED)) {
-                getTasks().remove(evt.getSource());
+            if (!retainTaskMode) {
+                if (evt.getEventType().equals(
+                        WorkerStateEvent.WORKER_STATE_SUCCEEDED)
+                        || evt.getEventType().equals(
+                        WorkerStateEvent.WORKER_STATE_CANCELLED)
+                        || evt.getEventType().equals(
+                        WorkerStateEvent.WORKER_STATE_FAILED)) {
+                    getTasks().remove(evt.getSource());
+                }
             }
         };
 
@@ -154,5 +158,23 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
      */
     public final void setGraphicFactory(Callback<T, Node> factory) {
         graphicFactoryProperty().set(factory);
+    }
+
+    /**
+     * Check if tasks will not be removed when succeeded, cancelled or failed
+     *
+     * @return
+     */
+    public boolean isRetainTaskMode() {
+        return retainTaskMode;
+    }
+
+    /**
+     * Do not remove tasks when succeeded, cancelled or failed
+     *
+     * @param retainTaskMode
+     */
+    public void setRetainTaskMode(boolean retainTaskMode) {
+        this.retainTaskMode = retainTaskMode;
     }
 }

--- a/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
@@ -180,4 +180,12 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
         return retainTasks;
     }
 
+    /**
+     * Do not remove tasks when succeeded, cancelled or failed
+     *
+     * @param retainTasks
+     */
+    public final void setRetainTasks(boolean retainTasks) {
+        this.retainTasks.set(retainTasks);
+    }
 }

--- a/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
@@ -27,7 +27,9 @@
 package org.controlsfx.control;
 
 import impl.org.controlsfx.skin.TaskProgressViewSkin;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -62,7 +64,7 @@ import javafx.util.Callback;
  */
 public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
 
-    private boolean retainTaskMode = false;
+    private BooleanProperty retainTasks = new SimpleBooleanProperty(this, "retainTasks", false);
 
     /**
      * Constructs a new task progress view.
@@ -71,7 +73,7 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
         getStyleClass().add("task-progress-view");
 
         EventHandler<WorkerStateEvent> taskHandler = evt -> {
-            if (!retainTaskMode) {
+            if (!retainTasks.get()) {
                 if (evt.getEventType().equals(
                         WorkerStateEvent.WORKER_STATE_SUCCEEDED)
                         || evt.getEventType().equals(
@@ -163,18 +165,19 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
     /**
      * Check if tasks will not be removed when succeeded, cancelled or failed
      *
-     * @return
+     * @return boolean
      */
-    public boolean isRetainTaskMode() {
-        return retainTaskMode;
+    public boolean isRetainTasks() {
+        return retainTasks.get();
     }
 
     /**
      * Do not remove tasks when succeeded, cancelled or failed
      *
-     * @param retainTaskMode
+     * @return BooleanProperty
      */
-    public void setRetainTaskMode(boolean retainTaskMode) {
-        this.retainTaskMode = retainTaskMode;
+    public BooleanProperty retainTasksProperty() {
+        return retainTasks;
     }
+
 }

--- a/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
@@ -64,7 +64,7 @@ import javafx.util.Callback;
  */
 public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
 
-    private BooleanProperty retainTasks = new SimpleBooleanProperty(this, "retainTasks", false);
+    private final BooleanProperty retainTasks = new SimpleBooleanProperty(this, "retainTasks", false);
 
     /**
      * Constructs a new task progress view.
@@ -73,7 +73,7 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
         getStyleClass().add("task-progress-view");
 
         EventHandler<WorkerStateEvent> taskHandler = evt -> {
-            if (!retainTasks.get()) {
+            if (!isRetainTasks()) {
                 if (evt.getEventType().equals(
                         WorkerStateEvent.WORKER_STATE_SUCCEEDED)
                         || evt.getEventType().equals(
@@ -167,7 +167,7 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
      *
      * @return boolean
      */
-    public boolean isRetainTasks() {
+    public final boolean isRetainTasks() {
         return retainTasks.get();
     }
 
@@ -176,7 +176,7 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
      *
      * @return BooleanProperty
      */
-    public BooleanProperty retainTasksProperty() {
+    public final BooleanProperty retainTasksProperty() {
         return retainTasks;
     }
 

--- a/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/TaskProgressView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2015 ControlsFX
+ * Copyright (c) 2014, 2019 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -163,27 +163,27 @@ public class TaskProgressView<T extends Task<?>> extends ControlsFXControl {
     }
 
     /**
-     * Check if tasks will not be removed when succeeded, cancelled or failed
+     * Checks if tasks will not be removed when succeeded, cancelled or failed.
      *
-     * @return boolean
+     * @return boolean determines if tasks will be retained
      */
     public final boolean isRetainTasks() {
         return retainTasks.get();
     }
 
     /**
-     * Do not remove tasks when succeeded, cancelled or failed
+     * Do not remove tasks when succeeded, cancelled or failed.
      *
-     * @return BooleanProperty
+     * @return BooleanProperty the retainTasks property
      */
     public final BooleanProperty retainTasksProperty() {
         return retainTasks;
     }
 
     /**
-     * Do not remove tasks when succeeded, cancelled or failed
+     * Do not remove tasks when succeeded, cancelled or failed.
      *
-     * @param retainTasks
+     * @param retainTasks determines if tasks will be retained
      */
     public final void setRetainTasks(boolean retainTasks) {
         this.retainTasks.set(retainTasks);


### PR DESCRIPTION
As discussed in #1118, a simple way to have TaskProgressView retaining a task after it's succeeded, cancelled or failed