### PR TITLE
Make javafx.web and javafx.media as optional modules

### DIFF
--- a/controlsfx/src/main/java/module-info.java
+++ b/controlsfx/src/main/java/module-info.java
@@ -4,8 +4,8 @@ module org.controlsfx.controls {
 
     requires transitive javafx.controls;
     requires transitive javafx.fxml;
-    requires transitive javafx.web;
-    requires transitive javafx.media;
+    requires static javafx.web;
+    requires static javafx.media;
 
     exports org.controlsfx.control;
     exports org.controlsfx.control.action;


### PR DESCRIPTION
I faced an issue in my project where I am not using javafx.web. I got the following error on application startup:

> java.lang.module.FindException: Module javafx.web not found, required by org.controlsfx.controls

Making this module as optional module solves the problem.