### PR TITLE
#1140 Fix NPE in Notifications

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/Notifications.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/Notifications.java
@@ -361,6 +361,9 @@ public class Notifications {
         }
 
         private Optional<Screen> getScreenBounds(Window window) {
+            if (window == null) {
+                return Optional.empty();
+            }
             final ObservableList<Screen> screensForRectangle = Screen.getScreensForRectangle(window.getX(),
                                                                                              window.getY(),
                                                                                              window.getWidth(),


### PR DESCRIPTION
Utils.getWindow(null) can return null and therefore we need to check if
there is a Window or we use primary window.