### PR TITLE
Wrap content in exception dialog

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/dialog/ExceptionDialog.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/ExceptionDialog.java
@@ -53,8 +53,9 @@ public class ExceptionDialog extends Dialog<ButtonType> {
         
         // --- content
         String contentText = getContentText();
-        dialogPane.setContent(new Label(contentText != null && ! contentText.isEmpty() ? 
-                contentText : exception.getMessage()));
+        Label contentLabel = new Label(contentText != null && ! contentText.isEmpty() ? contentText : exception.getMessage());
+        contentLabel.setWrapText(true);
+        dialogPane.setContent(contentLabel);
         
         // --- expandable content
         StringWriter sw = new StringWriter();


### PR DESCRIPTION
If you set a preferred width for the exception dialog, then the content message is simply cut-off if it is too long. 
![image](https://user-images.githubusercontent.com/5037600/57938196-f83bbb80-78c7-11e9-8039-cb52286b7208.png)

With this fix, the content should wrap nicely.