### PR TITLE
Fix build with Gradle 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,10 @@ subprojects {
     }
 
     // Used in Travis
-    task getVersion << {
-        println "$project.version"
+    task getVersion {
+        doLast {
+            println "$project.version"
+        }
     }
 
 }


### PR DESCRIPTION
Fix #1172

The left shift operator (`<<`) is deprecated since Gradle 3.2 and was removed from Gradle 5. With the left shift operator, controlsfx will not build using Gradle 5. I replaced it with the `doLast` block, which makes it build again with Gradle 5.