### PR TITLE
Validate completionTarget before showing autocomplete popup

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/textfield/AutoCompletionBinding.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/textfield/AutoCompletionBinding.java
@@ -411,7 +411,10 @@ public abstract class AutoCompletionBinding<T> implements EventTarget {
                 if(!isCancelled()){
                     final Collection<T> fetchedSuggestions = provider.call(this);
                     Platform.runLater(() -> {
-                        if(fetchedSuggestions != null && !fetchedSuggestions.isEmpty()){
+                        // check whether completionTarget is still valid
+                        boolean validNode = completionTarget.getScene() != null
+                                            && completionTarget.getScene().getWindow() != null;
+                        if(fetchedSuggestions != null && !fetchedSuggestions.isEmpty() && validNode){
                             autoCompletionPopup.getSuggestions().setAll(fetchedSuggestions);
                             showPopup();
                         }else{


### PR DESCRIPTION
This PR fixes #875.

My motivation: When using the autocompletion feature in a table cell editor, likelihood increases to run into the problem described in #875, because the table cell editor is removed from the scene graph frequently.

To avoid `IllegalStateException`s ("Can not show popup. The node must be attached to a scene/window.") thrown in `AutoCompletePopup.show(Node)`, we do the check in advance.

Thanks for having a look at it!