### PR TITLE
added support for the INFO Severity and refactored the messages storage

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
+++ b/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, ControlsFX
+ * Copyright (c) 2014, 2019, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
+++ b/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
@@ -50,7 +50,8 @@ public class ValidationResult {
     public ValidationResult() {}
 
     /**
-     * Factory method to create validation result out of one message
+     * Factory method to create validation result out of one message.
+     * Messages with {@link Severity#OK} will be ignored.
      * @param target validation target
      * @param text message text
      * @param severity message severity
@@ -182,7 +183,7 @@ public class ValidationResult {
     }
 
     /**
-     * Add one message to validation result with condition
+     * Add one message to validation result with condition. Messages with {@link Severity#OK} will be ignored.
      * @param target validation target
      * @param text message text
      * @param severity message severity
@@ -227,7 +228,7 @@ public class ValidationResult {
     }
 
     /**
-     * Add collection of validation messages
+     * Add collection of validation messages. Messages with {@link Severity#OK} will be ignored.
      * @param messages
      * @return updated validation result
      */
@@ -237,7 +238,7 @@ public class ValidationResult {
     }
 
     /**
-     * Add several validation messages
+     * Add several validation messages. Messages with {@link Severity#OK} will be ignored.
      * @param messages
      * @return updated validation result
      */
@@ -276,7 +277,7 @@ public class ValidationResult {
 
     /**
      * Retrieve errors represented by validation result
-     * @return collection of errors
+     * @return an unmodifiable collection of errors
      */
     public Collection<ValidationMessage> getErrors() {
         return getMessages(Severity.ERROR);
@@ -284,7 +285,7 @@ public class ValidationResult {
 
     /**
      * Retrieve warnings represented by validation result
-     * @return collection of warnings
+     * @return an unmodifiable collection of warnings
      */
     public Collection<ValidationMessage> getWarnings() {
         return getMessages(Severity.WARNING);
@@ -292,7 +293,7 @@ public class ValidationResult {
 
     /**
      * Retrieve infos represented by validation result
-     * @return collection of infos
+     * @return an unmodifiable collection of infos
      */
     public Collection<ValidationMessage> getInfos() {
         return getMessages(Severity.INFO);
@@ -300,7 +301,7 @@ public class ValidationResult {
 
     /**
      * Retrieve all messages represented by validation result
-     * @return collection of messages
+     * @return an unmodifiable collection of messages
      */
     public Collection<ValidationMessage> getMessages() {
         return getMessages(null);
@@ -309,7 +310,7 @@ public class ValidationResult {
     /**
      * Helper method to get all messages for a given severity.
      * A null severity will return all messages.
-     * @return collection of messages
+     * @return an unmodifiable collection of messages
      */
     private Collection<ValidationMessage> getMessages(Severity severity) {
         List<ValidationMessage> messages = severity == null ?

--- a/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
+++ b/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
@@ -114,7 +114,7 @@ public class ValidationResult {
         return fromMessages(ValidationMessage.warning(target, text));
     }
 
-        /**
+    /**
      * Factory method to create validation result out of one info
      * @param target validation target
      * @param text message text
@@ -169,15 +169,13 @@ public class ValidationResult {
     }
 
     /**
-     * Add one message to validation result
+     * Add one message to validation result. Messages with {@link Severity#OK} will be ignored.
      * @param message validation message
      * @return updated validation result
      */
     public ValidationResult add(ValidationMessage message) {
-        if (message != null) {
-            if (message.getSeverity() != Severity.OK) {
-                invalidMessages.add(message);
-            }
+        if (message != null && message.getSeverity() != Severity.OK) {
+            invalidMessages.add(message);
         }
 
         return this;

--- a/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
+++ b/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
@@ -31,18 +31,18 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.scene.control.Control;
 
 /**
  * Validation result. Can generally be thought of a collection of validation messages.
- * Allows for quick an painless accumulation of the messages. 
- * Also provides ability to combine validation results 
+ * Allows for quick an painless accumulation of the messages.
+ * Also provides ability to combine validation results
  */
 public class ValidationResult {
 
-    private List<ValidationMessage> errors   = new ArrayList<>();
-    private List<ValidationMessage> warnings = new ArrayList<>();
+    private List<ValidationMessage> invalidMessages = new ArrayList<>();
 
     /**
      * Creates empty validation result
@@ -51,56 +51,77 @@ public class ValidationResult {
 
     /**
      * Factory method to create validation result out of one message
-     * @param target validation target 
-     * @param text message text 
+     * @param target validation target
+     * @param text message text
      * @param severity message severity
      * @param condition condition on which message will be added to validation result
      * @return New instance of validation result
      */
-    public static final ValidationResult fromMessageIf( Control target, String text, Severity severity, boolean condition ) {
+    public static final ValidationResult fromMessageIf(Control target, String text, Severity severity, boolean condition) {
         return new ValidationResult().addMessageIf(target, text, severity, condition);
     }
 
     /**
      * Factory method to create validation result out of one error
-     * @param target validation target 
-     * @param text message text 
+     * @param target validation target
+     * @param text message text
      * @param condition condition on which message will be added to validation result
      * @return New instance of validation result
      */
-    public static final ValidationResult fromErrorIf( Control target, String text, boolean condition ) {
+    public static final ValidationResult fromErrorIf(Control target, String text, boolean condition) {
         return new ValidationResult().addErrorIf(target, text, condition);
     }
 
     /**
      * Factory method to create validation result out of one warning
-     * @param target validation target 
-     * @param text message text 
+     * @param target validation target
+     * @param text message text
      * @param condition condition on which message will be added to validation result
      * @return New instance of validation result
      */
-    public static final ValidationResult fromWarningIf( Control target, String text, boolean condition ) {
+    public static final ValidationResult fromWarningIf(Control target, String text, boolean condition) {
         return new ValidationResult().addWarningIf(target, text, condition);
     }
 
     /**
-     * Factory method to create validation result out of one error
-     * @param target validation target 
-     * @param text message text 
+     * Factory method to create validation result out of one info
+     * @param target validation target
+     * @param text message text
+     * @param condition condition on which message will be added to validation result
      * @return New instance of validation result
      */
-    public static final ValidationResult fromError( Control target, String text ) {
-        return fromMessages( ValidationMessage.error(target, text));
+    public static final ValidationResult fromInfoIf(Control target, String text, boolean condition) {
+        return new ValidationResult().addInfoIf(target, text, condition);
+    }
+
+    /**
+     * Factory method to create validation result out of one error
+     * @param target validation target
+     * @param text message text
+     * @return New instance of validation result
+     */
+    public static final ValidationResult fromError(Control target, String text) {
+        return fromMessages(ValidationMessage.error(target, text));
     }
 
     /**
      * Factory method to create validation result out of one warning
-     * @param target validation target 
-     * @param text message text 
+     * @param target validation target
+     * @param text message text
      * @return New instance of validation result
      */
-    public static final ValidationResult fromWarning( Control target, String text ) {
-        return fromMessages( ValidationMessage.warning(target, text));
+    public static final ValidationResult fromWarning(Control target, String text) {
+        return fromMessages(ValidationMessage.warning(target, text));
+    }
+
+        /**
+     * Factory method to create validation result out of one info
+     * @param target validation target
+     * @param text message text
+     * @return New instance of validation result
+     */
+    public static final ValidationResult fromInfo(Control target, String text) {
+        return fromMessages(ValidationMessage.info(target, text));
     }
 
     /**
@@ -108,7 +129,7 @@ public class ValidationResult {
      * @param messages
      * @return New instance of validation result
      */
-    public static final ValidationResult fromMessages( ValidationMessage... messages ) {
+    public static final ValidationResult fromMessages(ValidationMessage... messages) {
         return new ValidationResult().addAll(messages);
     }
 
@@ -117,7 +138,7 @@ public class ValidationResult {
      * @param messages
      * @return New instance of validation result
      */
-    public static final ValidationResult fromMessages( Collection<? extends ValidationMessage> messages ) {
+    public static final ValidationResult fromMessages(Collection<? extends ValidationMessage> messages) {
         return new ValidationResult().addAll(messages);
     }
 
@@ -126,7 +147,7 @@ public class ValidationResult {
      * @param results results
      * @return New instance of validation result, combining all into one
      */
-    public static final ValidationResult fromResults( ValidationResult... results ) {
+    public static final ValidationResult fromResults(ValidationResult... results) {
         return new ValidationResult().combineAll(results);
     }
 
@@ -135,7 +156,7 @@ public class ValidationResult {
      * @param results results
      * @return New instance of validation result, combining all into one
      */
-    public static final ValidationResult fromResults( Collection<ValidationResult> results ) {
+    public static final ValidationResult fromResults(Collection<ValidationResult> results) {
         return new ValidationResult().combineAll(results);
     }
 
@@ -152,12 +173,10 @@ public class ValidationResult {
      * @param message validation message
      * @return updated validation result
      */
-    public ValidationResult add( ValidationMessage message ) {
-
-        if ( message != null ) {
-            switch( message.getSeverity() ) {
-                case ERROR  : errors.add( message); break;
-                case WARNING: warnings.add(message); break;
+    public ValidationResult add(ValidationMessage message) {
+        if (message != null) {
+            if (message.getSeverity() != Severity.OK) {
+                invalidMessages.add(message);
             }
         }
 
@@ -169,33 +188,44 @@ public class ValidationResult {
      * @param target validation target
      * @param text message text
      * @param severity message severity
-     * @param condition condition on which message will be added 
+     * @param condition condition on which message will be added
      * @return updated validation result
      */
-    public ValidationResult addMessageIf( Control target, String text, Severity severity, boolean condition) {
-        return  condition? add( new SimpleValidationMessage(target, text, severity)): this;
+    public ValidationResult addMessageIf(Control target, String text, Severity severity, boolean condition) {
+        return condition ? add(new SimpleValidationMessage(target, text, severity)) : this;
     }
 
     /**
      * Add one error to validation result with condition
      * @param target validation target
      * @param text message text
-     * @param condition condition on which error will be added 
+     * @param condition condition on which error will be added
      * @return updated validation result
      */
-    public ValidationResult addErrorIf( Control target, String text, boolean condition) {
-        return addMessageIf(target,text,Severity.ERROR,condition);
+    public ValidationResult addErrorIf(Control target, String text, boolean condition) {
+        return addMessageIf(target, text, Severity.ERROR, condition);
     }
 
     /**
      * Add one warning to validation result with condition
      * @param target validation target
      * @param text message text
-     * @param condition condition on which warning will be added 
+     * @param condition condition on which warning will be added
      * @return updated validation result
      */
-    public ValidationResult addWarningIf( Control target, String text, boolean condition) {
-        return addMessageIf(target,text,Severity.WARNING,condition);
+    public ValidationResult addWarningIf(Control target, String text, boolean condition) {
+        return addMessageIf(target, text, Severity.WARNING, condition);
+    }
+
+       /**
+     * Add one info to validation result with condition
+     * @param target validation target
+     * @param text message text
+     * @param condition condition on which info will be added
+     * @return updated validation result
+     */
+    public ValidationResult addInfoIf(Control target, String text, boolean condition) {
+        return addMessageIf(target, text, Severity.INFO, condition);
     }
 
     /**
@@ -203,8 +233,8 @@ public class ValidationResult {
      * @param messages
      * @return updated validation result
      */
-    public ValidationResult addAll( Collection<? extends ValidationMessage> messages ) {
-        messages.stream().forEach( msg-> add(msg));
+    public ValidationResult addAll(Collection<? extends ValidationMessage> messages) {
+        messages.stream().forEach(msg -> add(msg));
         return this;
     }
 
@@ -213,7 +243,7 @@ public class ValidationResult {
      * @param messages
      * @return updated validation result
      */
-    public ValidationResult addAll( ValidationMessage... messages ) {
+    public ValidationResult addAll(ValidationMessage... messages) {
         return addAll(Arrays.asList(messages));
     }
 
@@ -222,8 +252,8 @@ public class ValidationResult {
      * @param validationResult
      * @return new instance of combined validation result
      */
-    public ValidationResult combine( ValidationResult validationResult ) {
-        return validationResult == null? copy(): copy().addAll(validationResult.getMessages());
+    public ValidationResult combine(ValidationResult validationResult) {
+        return validationResult == null ? copy(): copy().addAll(validationResult.getMessages());
     }
 
     /**
@@ -231,9 +261,9 @@ public class ValidationResult {
      * @param validationResults
      * @return new instance of combined validation result
      */
-    public ValidationResult combineAll( Collection<ValidationResult> validationResults ) {
+    public ValidationResult combineAll(Collection<ValidationResult> validationResults) {
         return validationResults.stream().reduce(copy(), (x,r) -> {
-            return r == null? x: x.addAll(r.getMessages());
+            return r == null ? x : x.addAll(r.getMessages());
         });
     }
 
@@ -242,8 +272,8 @@ public class ValidationResult {
      * @param validationResults
      * @return new instance of combined validation result
      */
-    public ValidationResult combineAll( ValidationResult... validationResults ) {
-        return combineAll( Arrays.asList(validationResults));
+    public ValidationResult combineAll(ValidationResult... validationResults) {
+        return combineAll(Arrays.asList(validationResults));
     }
 
     /**
@@ -251,7 +281,7 @@ public class ValidationResult {
      * @return collection of errors
      */
     public Collection<ValidationMessage> getErrors() {
-        return Collections.unmodifiableList(errors);
+        return getMessages(Severity.ERROR);
     }
 
     /**
@@ -259,7 +289,15 @@ public class ValidationResult {
      * @return collection of warnings
      */
     public Collection<ValidationMessage> getWarnings() {
-        return Collections.unmodifiableList(warnings);
+        return getMessages(Severity.WARNING);
+    }
+
+    /**
+     * Retrieve infos represented by validation result
+     * @return collection of infos
+     */
+    public Collection<ValidationMessage> getInfos() {
+        return getMessages(Severity.INFO);
     }
 
     /**
@@ -267,10 +305,21 @@ public class ValidationResult {
      * @return collection of messages
      */
     public Collection<ValidationMessage> getMessages() {
-        List<ValidationMessage> messages = new ArrayList<>();
-        messages.addAll(errors);
-        messages.addAll(warnings);
-        return Collections.unmodifiableList(messages);
+        return getMessages(null);
     }
 
+    /**
+     * Helper method to get all messages for a given severity.
+     * A null severity will return all messages.
+     * @return collection of messages
+     */
+    private Collection<ValidationMessage> getMessages(Severity severity) {
+        List<ValidationMessage> messages = severity == null ?
+            invalidMessages :
+            invalidMessages.parallelStream()
+                           .filter(msg -> msg.getSeverity() == severity)
+                           .collect(Collectors.toList());
+
+        return Collections.unmodifiableList(messages);
+    }
 }

--- a/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
+++ b/controlsfx/src/main/java/org/controlsfx/validation/ValidationResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2019, ControlsFX
+ * Copyright (c) 2014, 2019 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This is needed for Issue #1163. Currently the ValidationSupport model does not recognize messages that have the INFO Severity. This merge will add in that support.

Also refactor how messages are stored. Use one ArrayList instead of creating an Arraylist for each Severity type.
