### PR TITLE
Allow user to overwrite the rating icon

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/RatingSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/RatingSkin.java
@@ -259,14 +259,12 @@ public class RatingSkin extends BehaviorSkinBase<Rating, RatingBehavior> {
     	
     }
     
-//    private double getSpacing() {
-//        return (backgroundContainer instanceof HBox) ?
-//                ((HBox)backgroundContainer).getSpacing() :
-//                ((VBox)backgroundContainer).getSpacing();
-//    }
+    protected Node createButtonNode() {
+        return new Region();
+    }
     
     private Node createButton() {
-        Region btn = new Region();
+        Node btn = createButtonNode();
         btn.getStyleClass().add("button"); //$NON-NLS-1$
         
         btn.setOnMouseMoved(mouseMoveHandler);

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/RatingSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/RatingSkin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2015 ControlsFX
+ * Copyright (c) 2013, 2015, 2020 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -259,6 +259,11 @@ public class RatingSkin extends BehaviorSkinBase<Rating, RatingBehavior> {
     	
     }
     
+    /**
+     * Creates the node for one star.
+     * By default, an empty region is returned.
+     * This method can be overwritten to customize the styling of the star, e.g. to use a font-based icon.
+     */
     protected Node createButtonNode() {
         return new Region();
     }

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/RatingSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/RatingSkin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2015, 2020 ControlsFX
+ * Copyright (c) 2013, 2020, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
As of now it not possible to easily customize the look of the rating control apart from changing the look via css. Other customization like using font-based glyphs for the star are not possible.

This PR makes the creation of the star node protected so that one customize it by overriding.