### PR TITLE
Fix AutoCompletePopup location in RTL layouts

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/AutoCompletePopup.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/AutoCompletePopup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2019, ControlsFX
+ * Copyright (c) 2014, 2020, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/AutoCompletePopup.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/AutoCompletePopup.java
@@ -36,6 +36,7 @@ import javafx.collections.ObservableList;
 import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
+import javafx.geometry.NodeOrientation;
 import javafx.scene.Node;
 import javafx.scene.control.PopupControl;
 import javafx.scene.control.Skin;
@@ -147,7 +148,7 @@ public class AutoCompletePopup<T> extends PopupControl{
         this.show(
                 parent,
                 parent.getX() + node.localToScene(0, 0).getX() +
-                node.getScene().getX(),
+                node.getScene().getX() - (node.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT ? getWidth() : 0),
                 parent.getY() + node.localToScene(0, 0).getY() +
                 node.getScene().getY() + node.getBoundsInParent().getHeight());
 


### PR DESCRIPTION
When AutoCompletePopup is displayed for TextField in right to left layout, it's in incorrect location. I applied corrections to x position based on [Tooltip's code](https://github.com/openjdk/jfx/blob/master/modules/javafx.controls/src/main/java/javafx/scene/control/Tooltip.java#L893) in javafx repository.

Fixes #1247 