### PR TITLE
Fixing bottom GraphicDecoration by using decorationNodeHeight instead…

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/decoration/GraphicDecoration.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/decoration/GraphicDecoration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2017 ControlsFX
+ * Copyright (c) 2014, 2020 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -176,7 +176,7 @@ public class GraphicDecoration extends Decoration {
         		y -= decorationNodeHeight / 2.0;
         		break;
         	case BOTTOM:
-        		y += targetHeight - decorationNodeWidth / 2.0;
+        		y += targetHeight - decorationNodeHeight  / 2.0;
         		break;
         	case BASELINE: 
         		y += targetNode.getBaselineOffset() - decorationNode.getBaselineOffset() - decorationNodeHeight / 2.0;


### PR DESCRIPTION
Fixing bottom GraphicDecoration by using decorationNodeHeight instead of decorationNodeWidth

Fixes #1243 