### PR TITLE
Fix InaccessibleObjectException in GlyphFont

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@ ext.java9Args = [
         // For various usages of TraversalEngine
         "--add-exports=javafx.graphics/com.sun.javafx.scene=org.controlsfx.controls",
         "--add-exports=javafx.graphics/com.sun.javafx.scene.traversal=org.controlsfx.controls",
-        // For FontAwesome Style
-        "--add-exports=javafx.graphics/com.sun.javafx.css=org.controlsfx.controls",
         // For various behaviors across controls
         "--add-exports=javafx.controls/com.sun.javafx.scene.control.behavior=org.controlsfx.controls",
         // For ReadOnlyUnbackedObservableList across files
@@ -16,8 +14,6 @@ ext.java9Args = [
         "--add-exports=javafx.base/com.sun.javafx.collections=org.controlsfx.controls",
         // For VersionInfo in VersionChecker
         "--add-exports=javafx.base/com.sun.javafx.runtime=org.controlsfx.controls",
-        // For enabling FontAwesome
-        "--add-exports=javafx.graphics/com.sun.javafx.css=org.controlsfx.controls"
 ]
 
 ext.java9RuntimeArgs = [

--- a/controlsfx/src/main/java/impl/org/controlsfx/ReflectionUtils.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/ReflectionUtils.java
@@ -238,26 +238,6 @@ public class ReflectionUtils {
 
     /****************************************************************************************************
      *
-     * StyleManager
-     *
-     ****************************************************************************************************/
-
-    public static void addUserAgentStylesheet(String stylesheet) {
-        try {
-            Class<?> styleManagerClass = Class.forName("com.sun.javafx.css.StyleManager");
-            Method getInstance = styleManagerClass.getMethod("getInstance");
-            getInstance.setAccessible(true);
-            Object styleManager = getInstance.invoke(styleManagerClass);
-            Method addUserStyleSheet = styleManagerClass.getMethod("addUserAgentStylesheet", String.class);
-            addUserStyleSheet.setAccessible(true);
-            addUserStyleSheet.invoke(styleManager, stylesheet);
-        } catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
-            throw new RuntimeException("Cannot add UserAgentStylesheet as the method is not accessible");
-        }
-    }
-
-    /****************************************************************************************************
-     *
      * TraversalEngine
      *
      ****************************************************************************************************/

--- a/controlsfx/src/main/java/org/controlsfx/glyphfont/Glyph.java
+++ b/controlsfx/src/main/java/org/controlsfx/glyphfont/Glyph.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2015 ControlsFX
+ * Copyright (c) 2013, 2015, 2020 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -233,6 +233,10 @@ public class Glyph extends Label implements Duplicatable<Glyph> {
         }}
                 .fontFamily(getFontFamily())
                 .size(getFontSize());
+    }
+
+    @Override public String getUserAgentStylesheet() {
+        return Glyph.class.getResource("glyphfont.css").toExternalForm();
     }
 
     /***************************************************************************

--- a/controlsfx/src/main/java/org/controlsfx/glyphfont/Glyph.java
+++ b/controlsfx/src/main/java/org/controlsfx/glyphfont/Glyph.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2015, 2020 ControlsFX
+ * Copyright (c) 2013, 2020 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/org/controlsfx/glyphfont/GlyphFont.java
+++ b/controlsfx/src/main/java/org/controlsfx/glyphfont/GlyphFont.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2015, 2020 ControlsFX
+ * Copyright (c) 2013, 2020 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/org/controlsfx/glyphfont/GlyphFont.java
+++ b/controlsfx/src/main/java/org/controlsfx/glyphfont/GlyphFont.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2015, ControlsFX
+ * Copyright (c) 2013, 2015, 2020 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,6 @@
  */
 package org.controlsfx.glyphfont;
 
-import impl.org.controlsfx.ReflectionUtils;
 import javafx.scene.text.Font;
 
 import java.io.InputStream;
@@ -52,11 +51,6 @@ import java.util.Map;
  * <center><img src="glyphFont.png" alt="Screenshot of GlyphFont"></center>
  */
 public class GlyphFont {
-
-    static {
-        ReflectionUtils.addUserAgentStylesheet(
-                GlyphFont.class.getResource("glyphfont.css").toExternalForm()); //$NON-NLS-1$
-    }
 
     /***************************************************************************
      *                                                                         *


### PR DESCRIPTION
This fixes #1245.

Currently, `org.controlsfx.glyphfont.GlyphFont` uses reflection to add a user-agent style sheet ("glyphfont.css") which only affects `org.controlsfx.glyphfont.Glyph`. This reflection does not work when JavaFX is on the module path without an `--add-exports` argument.

This PR removes the use of reflection in `GlyphFont` and overrides [`Region#getUserAgentStylesheet()`][1] in `Glyph` to accomplish the same thing. That method is designed exactly for this use case:

>An implementation may specify its own user-agent styles for this Region, and its children, by overriding this method. These styles are used in addition to whatever user-agent stylesheets are in use. This provides a mechanism for third parties to introduce styles for custom controls. 

  [1]: https://openjfx.io/javadoc/14/javafx.graphics/javafx/scene/layout/Region.html#getUserAgentStylesheet()