### PR TITLE
Remove redundant javafx.swing module

### DIFF
--- a/controlsfx/build.gradle
+++ b/controlsfx/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 javafx {
-    modules = [ 'javafx.controls', 'javafx.media', 'javafx.swing' ]
+    modules = [ 'javafx.controls', 'javafx.media' ]
 }
 
 configurations {

--- a/controlsfx/src/main/java/module-info.java
+++ b/controlsfx/src/main/java/module-info.java
@@ -4,8 +4,6 @@ module org.controlsfx.controls {
 
     requires transitive javafx.controls;
     requires static javafx.media;
-    // Required for JavaFXThreadingRule
-    requires static javafx.swing;
 
     exports org.controlsfx.control;
     exports org.controlsfx.control.action;


### PR DESCRIPTION
With PR #1253, javafx.swing is no longer required and is now redundant.

Fixes #1252 