### PR TITLE
Enable headless testing

### DIFF
--- a/controlsfx/build.gradle
+++ b/controlsfx/build.gradle
@@ -131,6 +131,7 @@ test {
         systemProperty("testfx.headless", "true")
         systemProperty("prism.order", "sw")
         systemProperty("prism.text", "t2k")
+        systemProperty("headless.geometry", "1600x1200-32")
     }
     testLogging {
         // Show that tests are run in the command-line output

--- a/controlsfx/build.gradle
+++ b/controlsfx/build.gradle
@@ -10,7 +10,9 @@ ext {
 dependencies {
     testCompile 'junit:junit:[4,)'
     testCompile 'org.testfx:testfx-core:4.0.16-alpha'
-    testRuntime 'org.testfx:openjfx-monocle:jdk-11+26'
+    testRuntime ('org.testfx:openjfx-monocle:jdk-11+26') {
+        exclude group: 'org.openjfx'
+    }
 }
 
 javafx {
@@ -110,7 +112,10 @@ javadoc {
 ext.java9TestArgs = [
         "--add-reads=$moduleName=org.testfx",
         "--add-modules=org.testfx",
-        "--add-exports=javafx.graphics/com.sun.javafx.application=org.testfx"
+        "--add-exports=javafx.graphics/com.sun.javafx.application=org.testfx",
+        // For Monocle
+        "--add-exports=javafx.graphics/com.sun.glass.ui=org.testfx.monocle",
+        "--add-opens=javafx.graphics/com.sun.glass.ui=org.testfx"
 ]
 
 test {
@@ -118,6 +123,17 @@ test {
         java9Args.addAll(java9RuntimeArgs)
         java9Args.addAll(java9TestArgs)
         jvmArgs = java9Args
+    }
+    if (!project.hasProperty("headless") || project.headless == "true") {
+        // execute TestFX Tests headless -- switch off by using ./gradlew -Pheadless=false
+        systemProperty("testfx.robot", "glass")
+        systemProperty("testfx.headless", "true")
+        systemProperty("prism.order", "sw")
+        systemProperty("prism.text", "t2k")
+    }
+    testLogging {
+        // Show that tests are run in the command-line output
+        events 'started', 'passed'
     }
 }
 

--- a/controlsfx/build.gradle
+++ b/controlsfx/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 }
 
 javafx {
+    version = "11.0.2"
     modules = [ 'javafx.controls', 'javafx.media', 'javafx.swing' ]
 }
 

--- a/controlsfx/src/test/java/org/controlsfx/control/SearchableComboBoxTest.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/SearchableComboBoxTest.java
@@ -222,8 +222,7 @@ public class SearchableComboBoxTest extends FxRobot{
         robot.type(TAB);
 
         // when: "input search text '100'"
-        // Use Numpad instead of Digit for foreign keyboard (french for example)
-        robot.type(NUMPAD1, NUMPAD0, NUMPAD0);
+        robot.type(NUMPAD1, DIGIT0, DIGIT0);
 
         // then: "list is filtered"
         assertEquals(asList("100"), filteredComboBox.getItems());
@@ -235,8 +234,7 @@ public class SearchableComboBoxTest extends FxRobot{
         robot.type(TAB);
 
         // when: "input search text '1 00'"
-        // Use Numpad instead of Digit for foreign keyboard (french for example)
-        robot.type(NUMPAD1, SPACE, NUMPAD0, NUMPAD0);
+        robot.type(DIGIT1, SPACE, DIGIT0, DIGIT0);
 
         // then: "list is filtered"
         assertEquals(asList("100"), filteredComboBox.getItems());
@@ -261,8 +259,7 @@ public class SearchableComboBoxTest extends FxRobot{
         robot.type(TAB);
 
         // when: "input search text '100'"
-        // Use Numpad instead of Digit for foreign keyboard (french for example)
-        robot.type(NUMPAD1, NUMPAD0, NUMPAD0);
+        robot.type(DIGIT1, DIGIT0, DIGIT0);
 
         // then: "value is still selected"
         assertEquals(0, filteredComboBox.getSelectionModel().getSelectedIndex());
@@ -274,8 +271,7 @@ public class SearchableComboBoxTest extends FxRobot{
         robot.type(TAB);
 
         // when: "input search text '100'"
-        // Use Numpad instead of Digit for foreign keyboard (french for example)
-        robot.type(NUMPAD1, NUMPAD0, NUMPAD0);
+        robot.type(DIGIT1, DIGIT0, DIGIT0);
 
         // then: "no value is selected"
         assertEquals(-1, filteredComboBox.getSelectionModel().getSelectedIndex());


### PR DESCRIPTION
We recently enabled tests on 9.0.0 branch. This PR takes us a step forward and enables headless testing using `openjfx-monocle` from TestFX.