### PR TITLE
Move BreadCrumbButton to public api

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/BreadCrumbBarSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/BreadCrumbBarSkin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2015 ControlsFX
+ * Copyright (c) 2014, 2020 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,16 +41,10 @@ import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeItem.TreeModificationEvent;
-import javafx.scene.paint.Color;
-import javafx.scene.shape.ArcTo;
-import javafx.scene.shape.ClosePath;
-import javafx.scene.shape.HLineTo;
-import javafx.scene.shape.LineTo;
-import javafx.scene.shape.MoveTo;
-import javafx.scene.shape.Path;
 import javafx.util.Callback;
 
 import org.controlsfx.control.BreadCrumbBar;
+import org.controlsfx.control.BreadCrumbBar.BreadCrumbButton;
 import org.controlsfx.control.BreadCrumbBar.BreadCrumbActionEvent;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
@@ -244,138 +238,6 @@ public class BreadCrumbBarSkin<T> extends BehaviorSkinBase<BreadCrumbBar<T>, Beh
         // navigate to the clicked crumb
         if(breadCrumbBar.isAutoNavigationEnabled()){
             breadCrumbBar.setSelectedCrumb(crumbModel);
-        }
-    }
-
-    
-    
-    
-    /**
-     * Represents a BreadCrumb Button
-     * 
-     * <pre>
-     * ----------
-     *  \         \
-     *  /         /
-     * ----------
-     * </pre>
-     * 
-     * 
-     */
-    public static class BreadCrumbButton extends Button {
-
-        private final ObjectProperty<Boolean> first = new SimpleObjectProperty<>(this, "first"); //$NON-NLS-1$
-
-        private final double arrowWidth = 5;
-        private final double arrowHeight = 20;
-
-        /**
-         * Create a BreadCrumbButton
-         * 
-         * @param text Buttons text
-         */
-        public BreadCrumbButton(String text){
-            this(text, null);
-        }
-
-        /**
-         * Create a BreadCrumbButton
-         * @param text Buttons text
-         * @param gfx Gfx of the Button
-         */
-        public BreadCrumbButton(String text, Node gfx){
-            super(text, gfx);
-            first.set(false);
-
-            getStyleClass().addListener(new InvalidationListener() {
-                @Override public void invalidated(Observable arg0) {
-                    updateShape();
-                }
-            });
-
-            updateShape();
-        }
-
-        private void updateShape(){
-            this.setShape(createButtonShape());
-        }
-
-
-        /**
-         * Gets the crumb arrow with
-         * @return
-         */
-        public double getArrowWidth(){
-            return arrowWidth;
-        }
-
-        /**
-         * Create an arrow path
-         * 
-         * Based upon Uwe / Andy Till code snippet found here:
-         * @see http://ustesis.wordpress.com/2013/11/04/implementing-breadcrumbs-in-javafx/
-         * @return
-         */
-        private Path createButtonShape(){
-            // build the following shape (or home without left arrow)
-
-            //   --------
-            //  \         \
-            //  /         /
-            //   --------
-            Path path = new Path();
-
-            // begin in the upper left corner
-            MoveTo e1 = new MoveTo(0, 0);
-            path.getElements().add(e1);
-
-            // draw a horizontal line that defines the width of the shape
-            HLineTo e2 = new HLineTo();
-            // bind the width of the shape to the width of the button
-            e2.xProperty().bind(this.widthProperty().subtract(arrowWidth));
-            path.getElements().add(e2);
-
-            // draw upper part of right arrow
-            LineTo e3 = new LineTo();
-            // the x endpoint of this line depends on the x property of line e2
-            e3.xProperty().bind(e2.xProperty().add(arrowWidth));
-            e3.setY(arrowHeight / 2.0);
-            path.getElements().add(e3);
-
-            // draw lower part of right arrow
-            LineTo e4 = new LineTo();
-            // the x endpoint of this line depends on the x property of line e2
-            e4.xProperty().bind(e2.xProperty());
-            e4.setY(arrowHeight);
-            path.getElements().add(e4);
-
-            // draw lower horizontal line
-            HLineTo e5 = new HLineTo(0);
-            path.getElements().add(e5);
-
-            if(! getStyleClass().contains(STYLE_CLASS_FIRST)){
-                // draw lower part of left arrow
-                // we simply can omit it for the first Button
-                LineTo e6 = new LineTo(arrowWidth, arrowHeight / 2.0);
-                path.getElements().add(e6);
-            }else{
-                // draw an arc for the first bread crumb
-                ArcTo arcTo = new ArcTo();
-                arcTo.setSweepFlag(true);
-                arcTo.setX(0);
-                arcTo.setY(0);
-                arcTo.setRadiusX(15.0f);
-                arcTo.setRadiusY(15.0f);
-                path.getElements().add(arcTo);
-            }
-
-            // close path
-            ClosePath e7 = new ClosePath();
-            path.getElements().add(e7);
-            // this is a dummy color to fill the shape, it won't be visible
-            path.setFill(Color.BLACK);
-            
-            return path;
         }
     }
 }

--- a/controlsfx/src/main/java/org/controlsfx/control/BreadCrumbBar.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/BreadCrumbBar.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2015, ControlsFX
+ * Copyright (c) 2014, 2020, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,8 @@
 package org.controlsfx.control;
 
 import impl.org.controlsfx.skin.BreadCrumbBarSkin;
-import impl.org.controlsfx.skin.BreadCrumbBarSkin.BreadCrumbButton;
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
@@ -37,9 +38,17 @@ import javafx.event.Event;
 import javafx.event.EventDispatchChain;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Skin;
 import javafx.scene.control.TreeItem;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.ArcTo;
+import javafx.scene.shape.ClosePath;
+import javafx.scene.shape.HLineTo;
+import javafx.scene.shape.LineTo;
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.Path;
 import javafx.util.Callback;
 
 import com.sun.javafx.event.EventHandlerManager;
@@ -57,6 +66,7 @@ import java.util.UUID;
  * </center>
  */
 public class BreadCrumbBar<T> extends ControlsFXControl {
+    private static final String STYLE_CLASS_FIRST = "first"; //$NON-NLS-1$
 
     private final EventHandlerManager eventHandlerManager = new EventHandlerManager(this);
 
@@ -132,7 +142,7 @@ public class BreadCrumbBar<T> extends ControlsFXControl {
     private final Callback<TreeItem<T>, Button> defaultCrumbNodeFactory = new Callback<TreeItem<T>, Button>(){
         @Override
         public Button call(TreeItem<T> crumb) {
-            return new BreadCrumbBarSkin.BreadCrumbButton(crumb.getValue() != null ? crumb.getValue().toString() : ""); //$NON-NLS-1$
+            return new BreadCrumbButton(crumb.getValue() != null ? crumb.getValue().toString() : ""); //$NON-NLS-1$
         }
     };
     
@@ -340,5 +350,134 @@ public class BreadCrumbBar<T> extends ControlsFXControl {
     /** {@inheritDoc} */
     @Override public String getUserAgentStylesheet() {
         return getUserAgentStylesheet(BreadCrumbBar.class, "breadcrumbbar.css");
+    }
+
+    /**
+     * Represents a BreadCrumb Button
+     * 
+     * <pre>
+     * ----------
+     *  \         \
+     *  /         /
+     * ----------
+     * </pre>
+     * 
+     * 
+     */
+    public static class BreadCrumbButton extends Button {
+
+        private final ObjectProperty<Boolean> first = new SimpleObjectProperty<>(this, STYLE_CLASS_FIRST); //$NON-NLS-1$
+
+        private final double arrowWidth = 5;
+        private final double arrowHeight = 20;
+
+        /**
+         * Create a BreadCrumbButton
+         * 
+         * @param text Buttons text
+         */
+        public BreadCrumbButton(String text){
+            this(text, null);
+        }
+
+        /**
+         * Create a BreadCrumbButton
+         * @param text Buttons text
+         * @param gfx Gfx of the Button
+         */
+        public BreadCrumbButton(String text, Node gfx){
+            super(text, gfx);
+            first.set(false);
+
+            getStyleClass().addListener(new InvalidationListener() {
+                @Override public void invalidated(Observable arg0) {
+                    updateShape();
+                }
+            });
+
+            updateShape();
+        }
+
+        private void updateShape(){
+            this.setShape(createButtonShape());
+        }
+
+
+        /**
+         * Gets the crumb arrow with
+         * @return
+         */
+        public double getArrowWidth(){
+            return arrowWidth;
+        }
+
+        /**
+         * Create an arrow path
+         * 
+         * Based upon Uwe / Andy Till code snippet found here:
+         * @see http://ustesis.wordpress.com/2013/11/04/implementing-breadcrumbs-in-javafx/
+         * @return
+         */
+        private Path createButtonShape(){
+            // build the following shape (or home without left arrow)
+
+            //   --------
+            //  \         \
+            //  /         /
+            //   --------
+            Path path = new Path();
+
+            // begin in the upper left corner
+            MoveTo e1 = new MoveTo(0, 0);
+            path.getElements().add(e1);
+
+            // draw a horizontal line that defines the width of the shape
+            HLineTo e2 = new HLineTo();
+            // bind the width of the shape to the width of the button
+            e2.xProperty().bind(this.widthProperty().subtract(arrowWidth));
+            path.getElements().add(e2);
+
+            // draw upper part of right arrow
+            LineTo e3 = new LineTo();
+            // the x endpoint of this line depends on the x property of line e2
+            e3.xProperty().bind(e2.xProperty().add(arrowWidth));
+            e3.setY(arrowHeight / 2.0);
+            path.getElements().add(e3);
+
+            // draw lower part of right arrow
+            LineTo e4 = new LineTo();
+            // the x endpoint of this line depends on the x property of line e2
+            e4.xProperty().bind(e2.xProperty());
+            e4.setY(arrowHeight);
+            path.getElements().add(e4);
+
+            // draw lower horizontal line
+            HLineTo e5 = new HLineTo(0);
+            path.getElements().add(e5);
+
+            if(! getStyleClass().contains(STYLE_CLASS_FIRST)){
+                // draw lower part of left arrow
+                // we simply can omit it for the first Button
+                LineTo e6 = new LineTo(arrowWidth, arrowHeight / 2.0);
+                path.getElements().add(e6);
+            }else{
+                // draw an arc for the first bread crumb
+                ArcTo arcTo = new ArcTo();
+                arcTo.setSweepFlag(true);
+                arcTo.setX(0);
+                arcTo.setY(0);
+                arcTo.setRadiusX(15.0f);
+                arcTo.setRadiusY(15.0f);
+                path.getElements().add(arcTo);
+            }
+
+            // close path
+            ClosePath e7 = new ClosePath();
+            path.getElements().add(e7);
+            // this is a dummy color to fill the shape, it won't be visible
+            path.setFill(Color.BLACK);
+            
+            return path;
+        }
     }
 }


### PR DESCRIPTION
Moves the static BreadCrumbButton inner class from the inaccessible
impl.org.controlsfx.skin.BreadCrumbBarSkin class to the publicly
accessible org.controlsfx.controls.BreadCrumbBar class.
This allows users to customize the appearance of the BreadCrumbBar via
its setCrumbFactory method. While it is possible to call this method
with a generic Button, the internal layouting of the skin relies on
BreadCrumbButton to layout the buttons in an overlapping way.

This (to my best understanding) implements the solution outlined by @abhinayagarwal in
controlsfx/controlsfx#1109