### PR TITLE
Add workflow for CLA verification

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,73 @@
+name: CLA verification
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  cla-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - id: 'query-worksheet'
+        uses: jroehl/gsheet.action@release
+        with:
+          spreadsheetId: $GSHEET_ID
+          commands: |
+            [
+              { "command": "getData", "args": { "range": "'Form Responses'!E:E" } }
+            ]
+        env:
+          GSHEET_CLIENT_EMAIL: ${{ secrets.GSHEET_CLIENT_EMAIL }}
+          GSHEET_PRIVATE_KEY: ${{ secrets.GSHEET_PRIVATE_KEY }}
+          GSHEET_ID: ${{ secrets.GSHEET_ID }}
+      - name: Find username index
+        id: username-index
+        env:
+          RESULTS: ${{ steps.query-worksheet.outputs.results }}
+          GITHUB_USER_NAME: ${{ github.event.pull_request.user.login }}
+        shell: bash
+        run: |
+          index=`echo "$RESULTS" | jq -c '.results[].result.rawData | flatten | index(env.GITHUB_USER_NAME)'`
+          [ "$index" = "null" ] && echo "Username not found in list"
+          echo "::set-output name=index::$index"
+      - name: Add CLA Label and Comment
+        if: steps.username-index.outputs.index == 'null' && !contains(github.event.pull_request.labels.*.name, 'CLA')
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hi ${{ github.event.pull_request.user.login }},\n\nWelcome to ControlsFX and thank you for taking time to contribute to this project.\n\nWe do not recognise you as a contributor. Can you please sign ControlsFX Individual Contributor Agreement: https://cla.controlsfx.org ?'
+            })
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['CLA']
+            })
+      - name: Add CLA-VERIFIED Label
+        if: steps.username-index.outputs.index != 'null' && !contains(github.event.pull_request.labels.*.name, 'CLA-VERIFIED')
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['CLA-VERIFIED']
+            })
+      - name: Remove CLA Label
+        if: steps.username-index.outputs.index != 'null' && contains(github.event.pull_request.labels.*.name, 'CLA')
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'CLA'
+            })


### PR DESCRIPTION
Uses Github Action to automatically verify if a contributor has signed [ControlsFX CLA](https://cla.controlsfx.org).  The workflow does the following:

1. If a contributor is found, it will add a label `CLA-VERIFIED` to the PR
2. If a contributor is not found, it will add a label `CLA` to the PR and comment on the PR

![image](https://user-images.githubusercontent.com/3197675/110129521-0e44a400-7dee-11eb-8190-fbd76f588910.png)

Fixes #1255