### PR TITLE
TableView2: Check cell visibility before add/remove listener

### DIFF
--- a/controlsfx/build.gradle
+++ b/controlsfx/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     testRuntime ('org.testfx:openjfx-monocle:jdk-12.0.1+2') {
         exclude group: 'org.openjfx'
     }
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'org.hamcrest:hamcrest-library:2.2'
 }
 
 javafx {
@@ -109,7 +111,8 @@ ext.java9TestArgs = [
         "--add-exports=javafx.graphics/com.sun.javafx.application=org.testfx",
         // For Monocle
         "--add-exports=javafx.graphics/com.sun.glass.ui=org.testfx.monocle",
-        "--add-opens=javafx.graphics/com.sun.glass.ui=org.testfx"
+        "--add-opens=javafx.graphics/com.sun.glass.ui=org.testfx",
+        "--add-reads=$moduleName=org.hamcrest",
 ]
 
 test {

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
@@ -140,7 +140,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
         getChildren().removeIf(n -> n.getId() != null && n.getId().equals("pane-fixed-cell"));
             
         Object o = control.getProperties().get("fixed");
-        boolean fixedRow = o != null && ((Boolean) o).equals(Boolean.TRUE);
+        boolean fixedRow = Boolean.TRUE.equals(o);
 
         final List<? extends TableColumn<S, ?>> columns = tableView.getVisibleLeafColumns();
 
@@ -168,7 +168,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
         control.verticalShift.setValue(tableView.isRowFixingEnabled() ? getFixedRowShift(index) : 0);
 
         double fixedColumnWidth = 0;
-        List<TableCell<S, ?>> fixedCells = new ArrayList();
+        List<TableCell<S, ?>> fixedCells = new ArrayList<>();
 
         //We compute the cells here
         putCellsInCache();
@@ -184,33 +184,39 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
             if (! column.isVisible()) {
                 continue;
             }
-            final TableCell<S, ?> tableCell = getCell(column);
-            if (! isFirstColumn) {
-                tableCell.pseudoClassStateChanged(LEFT_CELL, true);
-                isFirstColumn = true;
-            }
-            
-            TablePosition<S, ?> pos = new TablePosition<>(tableView, tableCell.getIndex(), column);
-        
-            width = snapSize(column.getWidth()) - snapSize(horizontalPadding);
+
+            TablePosition<S, ?> pos = new TablePosition<>(tableView, index, column);
+
+            width = snapSizeX(column.getWidth()) - snapSizeX(horizontalPadding);
             //When setting a new grid with less columns, we may have this situation.
             final int columnSpan = tableView.getColumnSpan(pos);
             boolean isVisible = !isInvisible(x, width, hbarValue, headerWidth, columnSpan);
-            while (column.getParentColumn() != null) {
+            TableColumn<?,?> rootColumn = column;
+            while (rootColumn.getParentColumn() != null) {
                 // on nested columns, we check if the root parent is the one fixed
-                column = (TableColumn<S, ?>) column.getParentColumn();
+                rootColumn = (TableColumn<?, ?>) rootColumn.getParentColumn();
             }
-            
-            if (tableView.isColumnFixingEnabled() && tableView.getFixedColumns().contains(column)) {
+
+            if (tableView.isColumnFixingEnabled() && tableView.getFixedColumns().contains(rootColumn)) {
                 isVisible = true;
             }
 
             if (!isVisible) {
+                TableCell<S, ?> cell = getCellsMap().remove(column);
+                if (cell != null) {
+                    getChildren().remove(cell);
+                }
                 if (firstVisibleCell) {
                     break;
                 }
                 x += width;
                 continue;
+            }
+
+            final TableCell<S, ?> tableCell = getCell(column);
+            if (! isFirstColumn) {
+                tableCell.pseudoClassStateChanged(LEFT_CELL, true);
+                isFirstColumn = true;
             }
             
             cells.add(0, tableCell);

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
@@ -57,20 +57,20 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
     private static final PseudoClass RIGHT_CELL = PseudoClass.getPseudoClass("right");
     private static final PseudoClass SINGLE_CELL = PseudoClass.getPseudoClass("single");
     private static final PseudoClass FIXED_CELL = PseudoClass.getPseudoClass("fixed");
-            
+
     private final TableView2<S> tableView;
     private final TableView2Skin<S> skin;
 
     private Reference<HashMap<TableColumnBase, TableCell<S, ?>>> cellsMap;
 
     private final List<TableCell<S, ?>> cells = new ArrayList<>();
-    
+
     private final TableView2<S> parentTableView;
-    
+
     public TableRow2Skin(TableView2<S> tableView, TableRow<S> tableRow) {
         super(tableRow);
         this.tableView = tableView;
-        
+
         getSkinnable().setPickOnBounds(false);
 
         registerChangeListener(tableRow.itemProperty(), t -> requestCellUpdate());
@@ -83,7 +83,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
                 requestCellUpdate();
             }
         });
-        
+
         if (tableView.getParent() != null && tableView.getParent() instanceof RowHeader) {
             parentTableView = ((RowHeader) tableView.getParent()).getParentTableView();
             this.skin = (TableView2Skin<S>) parentTableView.getSkin();
@@ -103,11 +103,6 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
         // issue highlighted in JDK-8115269, where the table cell had the correct
         // item whilst the row had the old item.
         final int newIndex = getSkinnable().getIndex();
-        /**
-         * When the index is changing, we need to clear out all the children
-         * because we may end up with useless cell in the row.
-         */
-        getChildren().clear();
         for (int i = 0, max = cells.size(); i < max; i++) {
             cells.get(i).updateIndex(newIndex);
         }
@@ -136,9 +131,9 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
             putCellsInCache();
             return;
         }
-        
+
         getChildren().removeIf(n -> n.getId() != null && n.getId().equals("pane-fixed-cell"));
-            
+
         Object o = control.getProperties().get("fixed");
         boolean fixedRow = Boolean.TRUE.equals(o);
 
@@ -218,7 +213,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
                 tableCell.pseudoClassStateChanged(LEFT_CELL, true);
                 isFirstColumn = true;
             }
-            
+
             cells.add(0, tableCell);
 
             // In case the node was treated previously
@@ -251,174 +246,170 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
                 if (hbarValue + fixedColumnWidth > x) {
                     increaseFixedWidth = true;
                     tableCellX = Math.abs(hbarValue - x + fixedColumnWidth);
-//                	 tableCell.toFront();
+//                	tableCell.toFront();
                     fixedColumnWidth += width;
-//                    isVisible = true; // If in fixedColumn, it's obviously visible
+//                  isVisible = true; // If in fixedColumn, it's obviously visible
                     fixedCells.add(tableCell);
                 }
             }
-            
-            if (isVisible) {
-                final TableView2.SpanType spanType = tableView.getSpanType(index, indexColumn);
 
-                switch (spanType) {
-                    case ROW_SPAN_INVISIBLE:
-                    case BOTH_INVISIBLE:
-                        fixedCells.remove(tableCell);
-                        getChildren().remove(tableCell);
-//                        cells.remove(tableCell);
-                        x += width;
-                        continue; // we don't want to fall through
-                    case COLUMN_SPAN_INVISIBLE:
-                        fixedCells.remove(tableCell);
-                        getChildren().remove(tableCell);
-//                        cells.remove(tableCell);
-                        continue; // we don't want to fall through
-                    case ROW_VISIBLE:
-                    case NORMAL_CELL: // fall through and carry on
-                        if (tableCell.getIndex() != index) {
-                            tableCell.updateIndex(index);
-                        } else {
-//                            tableCell.updateItem(tableCell.getItem(), false); 
-                            tableCell.updateIndex(index);
-                            tableCell.requestLayout();
-                        }
-                        /**
-                         * Here we need to add the cells on the first position
-                         * because this row may contain some deported cells from
-                         * other rows in order to be on top in term of z-order.
-                         * So the cell we're currently adding must not recover
-                         * them. We must check that the parent is indeed the
-                         * getSkinnable because of the deportedCells.
-                         */
-                        if (!tableCell.isEditing() && tableCell.getParent() != getSkinnable()) {
-                            getChildren().add(0, tableCell);
-                        }
-                }
+            final TableView2.SpanType spanType = tableView.getSpanType(index, indexColumn);
 
-                /**
-                 * Check selection. 
-                 * Fixes a bug in cell selection after a column is hidden 
-                 */
-                if (tableView.getSelectionModel() != null && tableView.getSelectionModel().isCellSelectionEnabled()) {
-                    final int ic = indexColumn;
-                    boolean select = ! tableView.getSelectionModel().getSelectedCells().stream()
-                                .noneMatch(cell -> cell.getRow() == index && cell.getColumn() == ic);
-                    tableCell.pseudoClassStateChanged(SELECTED, select);
-                }
-                
-                if (columnSpan > 1) {
+            switch (spanType) {
+                case ROW_SPAN_INVISIBLE:
+                case BOTH_INVISIBLE:
+                    fixedCells.remove(tableCell);
+                    getChildren().remove(tableCell);
+//                  cells.remove(tableCell);
+                    x += width;
+                    continue; // we don't want to fall through
+                case COLUMN_SPAN_INVISIBLE:
+                    fixedCells.remove(tableCell);
+                    getChildren().remove(tableCell);
+//                  cells.remove(tableCell);
+                    continue; // we don't want to fall through
+                case ROW_VISIBLE:
+                case NORMAL_CELL: // fall through and carry on
+                    if (tableCell.getIndex() != index) {
+                        tableCell.updateIndex(index);
+                    } else {
+//                      tableCell.updateItem(tableCell.getItem(), false);
+                        tableCell.updateIndex(index);
+                        tableCell.requestLayout();
+                    }
                     /**
-                     * we need to span multiple columns, so we sum up the width
-                     * of the additional columns, adding it to the width
-                     * variable
+                     * Here we need to add the cells on the first position
+                     * because this row may contain some deported cells from
+                     * other rows in order to be on top in term of z-order.
+                     * So the cell we're currently adding must not recover
+                     * them. We must check that the parent is indeed the
+                     * getSkinnable because of the deportedCells.
                      */
-                    int viewColumn = skin.getViewColumn(indexColumn);
-                    final int max = tableView.getVisibleLeafColumns().size() - viewColumn;
-                    for (int i = 1, colSpan = columnSpan; i < colSpan && i < max; i++) {
-                        double tempWidth = snapSize(tableView.getVisibleLeafColumn(viewColumn + i).getWidth());
-                        width += tempWidth;
-                        if (increaseFixedWidth) {
-                            fixedColumnWidth += tempWidth;
-                        }
+                    if (!tableCell.isEditing() && tableCell.getParent() != getSkinnable()) {
+                        getChildren().add(0, tableCell);
                     }
-                }
-                    
-                /**
-                 * If we are in autofit and the prefHeight of this cell is
-                 * superior to the default cell height. Then we will use this
-                 * new height for row's height.
-                 *
-                 * We then need to apply the value to previous cell, and also
-                 * layout the children because since we are layouting upward,
-                 * next rows needs to know that this row is bigger than usual.
-                 */
-                if (!tableCell.isEditing()) {
-                    //We have the problem when we are just one pixel short in height..
-                    double tempHeight = tableCell.prefHeight(width) + tableCell.snappedTopInset() + tableCell.snappedBottomInset();
-                    if (parentTableView != null) {
-                        // for the row header take the height from the max tempHeight from the parent TableRow
-                        if (control.getIndex() < skin.getItemCount()) {
-                            tempHeight = skin.rowHeightMap.getOrDefault(control.getIndex(), tempHeight);
-                        }
-                    }
-            
-                    if (tempHeight > customHeight) {
-                        rowHeightChange = true;
-                        skin.rowHeightMap.put(control.getIndex(), tempHeight);
-                        for (TableCell<S, ?> cell : cells) {
-                            /**
-                             * We need to add the difference between the
-                             * previous height and the new height. If we were
-                             * just setting the new height, the row spanning
-                             * cell would be shorter. That's why we need to use
-                             * the cell height.
-                             */
-                            cell.resize(cell.getWidth(), cell.getHeight() + (tempHeight - customHeight));
-                        }
-                        customHeight = tempHeight;
-                        if (parentTableView != null) {
-                            ((TableView2Skin<S>) tableView.getSkin()).getFlow().layoutChildren();
-                        } else {
-                            ((TableView2Skin<S>) skin).getFlow().layoutChildren();
-                        }
-                    }
-                }
-
-                height = customHeight;
-                height = snapSize(height) - snapSize(verticalPadding);
-                /**
-                 * We need to span multiple rows, so we sum up the height of all
-                 * the rows. The height of the current row is ignored and the
-                 * whole value is computed.
-                 */
-                int rowSpan = tableView.getRowSpan(pos, index);
-                if (rowSpan > 1) {
-                    height = 0;
-                    final int maxRow = index + rowSpan;
-                    for (int i = index; i < maxRow; ++i) {
-                        height += snapSize(skin.getRowHeight(i));
-                    }
-                }
-
-                //Fix for JDK-8146406
-                needToBeShifted = false;
-                /**
-                 * If the current cell has no left border, and the previous cell
-                 * had no right border. We may have the problem
-                 * where there is a tiny gap between the cells when scrolling
-                 * horizontally. Thus we must enlarge this cell a bit, and shift
-                 * it a bit in order to mask that gap. If the cell has a border
-                 * defined, the problem seems not to happen.
-                 * If the cell is not added to its parent, it has no border by default so we must not check it.
-                 */
-                if (/*tableView.getFixedRows().contains(tableView2Cell.getRow())
-                        && */lastCell != null
-                        && !hasRightBorder(lastCell)
-                        && !hasLeftBorder(tableCell)) {
-                    tableCell.resize(width + 1, height);
-                    needToBeShifted = true;
-                } else {
-                    tableCell.resize(width, height);
-                }
-                lastCell = tableCell;
-                // We want to place the layout always at the starting cell.
-                double spaceBetweenTopAndMe = 0;
-//                for (int p = tableView2Cell.getRow(); p < index; ++p) {
-//                    spaceBetweenTopAndMe += skin.getRowHeight(p);
-//                }
-
-                tableCell.relocate(x + tableCellX + (needToBeShifted? -1 : 0), snappedTopInset()
-                        - spaceBetweenTopAndMe + control.verticalShift.get());
-
-                // Request layout is here as (partial) fix for JDK-8118040
-//                 tableCell.requestLayout();
-            } else {
-                getChildren().remove(tableCell);
             }
+
+            /**
+             * Check selection.
+             * Fixes a bug in cell selection after a column is hidden
+             */
+            if (tableView.getSelectionModel() != null && tableView.getSelectionModel().isCellSelectionEnabled()) {
+                final int ic = indexColumn;
+                boolean select = ! tableView.getSelectionModel().getSelectedCells().stream()
+                        .noneMatch(cell -> cell.getRow() == index && cell.getColumn() == ic);
+                tableCell.pseudoClassStateChanged(SELECTED, select);
+            }
+
+            if (columnSpan > 1) {
+                /**
+                 * we need to span multiple columns, so we sum up the width
+                 * of the additional columns, adding it to the width
+                 * variable
+                 */
+                int viewColumn = skin.getViewColumn(indexColumn);
+                final int max = tableView.getVisibleLeafColumns().size() - viewColumn;
+                for (int i = 1, colSpan = columnSpan; i < colSpan && i < max; i++) {
+                    double tempWidth = snapSize(tableView.getVisibleLeafColumn(viewColumn + i).getWidth());
+                    width += tempWidth;
+                    if (increaseFixedWidth) {
+                        fixedColumnWidth += tempWidth;
+                    }
+                }
+            }
+
+            /**
+             * If we are in autofit and the prefHeight of this cell is
+             * superior to the default cell height. Then we will use this
+             * new height for row's height.
+             *
+             * We then need to apply the value to previous cell, and also
+             * layout the children because since we are layouting upward,
+             * next rows needs to know that this row is bigger than usual.
+             */
+            if (!tableCell.isEditing()) {
+                //We have the problem when we are just one pixel short in height..
+                double tempHeight = tableCell.prefHeight(width) + tableCell.snappedTopInset() + tableCell.snappedBottomInset();
+                if (parentTableView != null) {
+                    // for the row header take the height from the max tempHeight from the parent TableRow
+                    if (control.getIndex() < skin.getItemCount()) {
+                        tempHeight = skin.rowHeightMap.getOrDefault(control.getIndex(), tempHeight);
+                    }
+                }
+
+                if (tempHeight > customHeight) {
+                    rowHeightChange = true;
+                    skin.rowHeightMap.put(control.getIndex(), tempHeight);
+                    for (TableCell<S, ?> cell : cells) {
+                        /**
+                         * We need to add the difference between the
+                         * previous height and the new height. If we were
+                         * just setting the new height, the row spanning
+                         * cell would be shorter. That's why we need to use
+                         * the cell height.
+                         */
+                        cell.resize(cell.getWidth(), cell.getHeight() + (tempHeight - customHeight));
+                    }
+                    customHeight = tempHeight;
+                    if (parentTableView != null) {
+                        ((TableView2Skin<S>) tableView.getSkin()).getFlow().layoutChildren();
+                    } else {
+                        ((TableView2Skin<S>) skin).getFlow().layoutChildren();
+                    }
+                }
+            }
+
+            height = customHeight;
+            height = snapSize(height) - snapSize(verticalPadding);
+            /**
+             * We need to span multiple rows, so we sum up the height of all
+             * the rows. The height of the current row is ignored and the
+             * whole value is computed.
+             */
+            int rowSpan = tableView.getRowSpan(pos, index);
+            if (rowSpan > 1) {
+                height = 0;
+                final int maxRow = index + rowSpan;
+                for (int i = index; i < maxRow; ++i) {
+                    height += snapSize(skin.getRowHeight(i));
+                }
+            }
+
+            //Fix for JDK-8146406
+            needToBeShifted = false;
+            /**
+             * If the current cell has no left border, and the previous cell
+             * had no right border. We may have the problem
+             * where there is a tiny gap between the cells when scrolling
+             * horizontally. Thus we must enlarge this cell a bit, and shift
+             * it a bit in order to mask that gap. If the cell has a border
+             * defined, the problem seems not to happen.
+             * If the cell is not added to its parent, it has no border by default so we must not check it.
+             */
+            if (/*tableView.getFixedRows().contains(tableView2Cell.getRow())
+                    && */lastCell != null
+                    && !hasRightBorder(lastCell)
+                    && !hasLeftBorder(tableCell)) {
+                tableCell.resize(width + 1, height);
+                needToBeShifted = true;
+            } else {
+                tableCell.resize(width, height);
+            }
+            lastCell = tableCell;
+            // We want to place the layout always at the starting cell.
+            double spaceBetweenTopAndMe = 0;
+//          for (int p = tableView2Cell.getRow(); p < index; ++p) {
+//              spaceBetweenTopAndMe += skin.getRowHeight(p);
+//          }
+
+            tableCell.relocate(x + tableCellX + (needToBeShifted? -1 : 0), snappedTopInset()
+                    - spaceBetweenTopAndMe + control.verticalShift.get());
+
+            // Request layout is here as (partial) fix for JDK-8118040
+//          tableCell.requestLayout();
             x += width;
         }
-        
+
         // When the table is wider than the columns, the empty space to the
         // right is visible and can be part of the row selection or scrolled. 
         double paneWidth = tableView.getWidth() - x - tableView.snappedLeftInset() - tableView.snappedRightInset();
@@ -428,7 +419,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
         if (skin.getVBar().isVisible()) {
             paneWidth -= skin.getVBar().getWidth();
         }
-        
+
         final int paneBorderInset = 1; // selection border inset in pane
         final boolean paneBorderVisible = paneWidth > paneBorderInset;
         final boolean singleColumn = columns.size() == 1;
@@ -444,8 +435,8 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
             pane.pseudoClassStateChanged(RIGHT_CELL, paneBorderVisible);
             pane.resizeRelocate(x, snappedTopInset() + control.verticalShift.get(), paneWidth, height);
             getChildren().add(pane);
-        } 
-        
+        }
+
         if (lastCell != null) {
             // In case of row selection, when the table is wider than the columns, 
             // the cells don't require a right selection border: the tableRow 
@@ -453,12 +444,12 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
             // pane will provide it in case of fixed rows.
             lastCell.pseudoClassStateChanged(RIGHT_CELL, ! singleColumn && ! paneBorderVisible);
             lastCell.pseudoClassStateChanged(SINGLE_CELL, singleColumn && ! paneBorderVisible);
-         
+
             if (parentTableView != null) {
                 lastCell.pseudoClassStateChanged(FIXED_CELL, fixedRow && control.getIndex() < skin.getItemCount());
             }
         }
-        
+
         skin.fixedColumnWidth = fixedColumnWidth;
         handleFixedCell(fixedCells, index);
         removeUselessCell(index);
@@ -531,7 +522,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
      * @param fixedCells
      * @param index
      */
-     private void handleFixedCell(List<TableCell<S, ?>> fixedCells, int index) {
+    private void handleFixedCell(List<TableCell<S, ?>> fixedCells, int index) {
         removeDeportedCells();
         if (fixedCells.isEmpty()) {
             return;
@@ -630,18 +621,18 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
             cell.updateTableColumn(tableColumn);
             cell.updateTableView(tableColumn.getTableView());
             cell.updateTableRow(getSkinnable());
-        
+
             if (parentTableView != null) {
                 cell.setOnContextMenuRequested(e -> {
                     BiFunction<Integer, S, ContextMenu> cmFactory = parentTableView.getRowHeaderContextMenuFactory();
                     if (tableView.getItems() != null && cmFactory != null) {
                         ContextMenu contextMenu = cmFactory.apply(getSkinnable().getIndex(), getSkinnable().getItem());
                         contextMenu.show(tableView.getScene().getWindow(), e.getScreenX(), e.getScreenY());
-                    } 
+                    }
                 });
             }
         }
-        
+
         cell.pseudoClassStateChanged(LEFT_CELL, false);
         cell.pseudoClassStateChanged(RIGHT_CELL, false);
         cell.pseudoClassStateChanged(SINGLE_CELL, false);

--- a/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
@@ -2,6 +2,7 @@ package org.controlsfx.control.tableview2;
 
 import impl.org.controlsfx.tableview2.TableRow2;
 import impl.org.controlsfx.tableview2.TableRow2Skin;
+import impl.org.controlsfx.tableview2.TableView2Skin;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -14,6 +15,10 @@ import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.util.Callback;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,6 +31,7 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -42,11 +48,11 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TableView2Test extends FxRobot {
 
-    private static class Row {
+    private static class RowItem {
 
         public final SimpleStringProperty[] values;
 
-        public Row(int rowIndex, int columnCount) {
+        public RowItem(int rowIndex, int columnCount) {
             values = new SimpleStringProperty[columnCount];
             for (int i = 0; i < this.values.length; i++) {
                 this.values[i] = new SimpleStringProperty(rowIndex + "x" + i);
@@ -63,13 +69,12 @@ public class TableView2Test extends FxRobot {
     private static final int NUMBER_OF_SELECTION_CHANGES = 20;
     private static final Duration MAX_DURATION_FOR_SELECTION_CHANGES = Duration.ofSeconds(NUMBER_OF_SELECTION_CHANGES);
 
-    private TableView2<Row> tableView;
-    private ObservableList<Row> data;
+    private TableView2<RowItem> tableView;
+    private ObservableList<RowItem> data;
     private AtomicBoolean allowedToRun;
     private ExecutorService dataManipulators;
     private CountDownLatch dataManipulationCountdown;
     private AtomicLong numberRowChildrenModifications;
-
 
     @BeforeClass
     public static void beforeAll() throws TimeoutException {
@@ -97,32 +102,33 @@ public class TableView2Test extends FxRobot {
     }
 
     private void populateTable() {
-        tableView.skinProperty().addListener(e -> {
-            tableView.rowFactoryProperty()
-                    .unbind();
-            tableView.setRowFactory(param -> {
-                final TableRow2<Row> rowTableRow2 = new TableRow2<>(tableView);
-                rowTableRow2.skinProperty().addListener(observable -> {
-                    final TableRow2Skin<?> skin = (TableRow2Skin<?>) rowTableRow2.getSkin();
-                    skin.getChildren().addListener((ListChangeListener<? super Node>) c -> {
-                        numberRowChildrenModifications.incrementAndGet();
+        tableView.skinProperty()
+                .addListener(e -> {
+                    tableView.rowFactoryProperty()
+                            .unbind();
+                    tableView.setRowFactory(param -> {
+                        final TableRow2<RowItem> rowTableRow2 = new TableRow2<>(tableView);
+                        rowTableRow2.skinProperty()
+                                .addListener(observable -> {
+                                    final TableRow2Skin<?> skin = (TableRow2Skin<?>) rowTableRow2.getSkin();
+                                    skin.getChildren()
+                                            .addListener((ListChangeListener<? super Node>) c -> numberRowChildrenModifications.incrementAndGet());
+                                });
+                        return rowTableRow2;
                     });
                 });
-                return rowTableRow2;
-            });
-        });
-        List<TableColumn2<Row, String>> fixed = new ArrayList<>();
+        List<TableColumn2<RowItem, String>> fixed = new ArrayList<>();
         tableView.getColumns()
                 .setAll(IntStream.range(0, NUMBER_OF_COLUMNS)
                         .mapToObj(index -> {
-                            TableColumn2<Row, String> column = new TableColumn2<>();
+                            TableColumn2<RowItem, String> column = new TableColumn2<>();
                             column.setId("column_" + index);
                             column.setText("#" + index);
                             column.setCellValueFactory(param -> param.getValue().values[index]);
                             if (index < 3) {
                                 fixed.add(column);
                             }
-                            final Callback<TableColumn<Row, String>, TableCell<Row, String>> cellFactory = column.getCellFactory();
+                            final Callback<TableColumn<RowItem, String>, TableCell<RowItem, String>> cellFactory = column.getCellFactory();
                             column.setCellFactory(cellFactory);
                             return column;
                         })
@@ -135,10 +141,9 @@ public class TableView2Test extends FxRobot {
     }
 
     private void fillTableData() {
-        data
-                .setAll(IntStream.range(0, NUMBER_OF_ROWS)
-                        .mapToObj((int rowIndex) -> new Row(rowIndex, NUMBER_OF_COLUMNS))
-                        .collect(Collectors.toList()));
+        data.setAll(IntStream.range(0, NUMBER_OF_ROWS)
+                .mapToObj((int rowIndex) -> new RowItem(rowIndex, NUMBER_OF_COLUMNS))
+                .collect(Collectors.toList()));
     }
 
     private void setupManipulators() {
@@ -155,8 +160,9 @@ public class TableView2Test extends FxRobot {
                     return;
                 }
                 while (allowedToRun.get()) {
-                    Row row = tableView.getItems().get(random.nextInt(NUMBER_OF_ROWS));
-                    row.values[random.nextInt(row.values.length)].set((100 + random.nextInt(100)) + "");
+                    RowItem rowItem = tableView.getItems()
+                            .get(random.nextInt(NUMBER_OF_ROWS));
+                    rowItem.values[random.nextInt(rowItem.values.length)].set((100 + random.nextInt(100)) + "");
                 }
             });
         }
@@ -183,15 +189,28 @@ public class TableView2Test extends FxRobot {
         fillTableData();
         produceUpdateLoad();
 
-        Duration timeTaken = measure(this::scrollVertical);
+        Duration timeTaken = measure(this::scrollDownAndUp);
         assertThat(timeTaken, is(lessThan(MAX_DURATION_FOR_SELECTION_CHANGES)));
     }
 
     @Test
     public void shouldReuseItems_When_ScrollingVertically() {
         fillTableData();
-        measure(this::scrollVertical);
+        measure(() -> scrollDown(60));
+        numberRowChildrenModifications.set(0);
+        measure(() -> scrollUp(60));
         assertThat(numberRowChildrenModifications.get(), is(0L));
+    }
+
+    @Test
+    public void shouldHaveNoArtifacts_When_ScrollingVertically() {
+        fillTableData();
+        measure(() -> scrollDown(40));
+        TableView2Skin<?> skin = (TableView2Skin<?>) tableView.getSkin();
+        TableRow2<?> firstVisibleRow = (TableRow2<?>) skin.getRow(0);
+        assertThat(firstVisibleRow, is(inSyncWithTable(tableView)));
+        measure(() -> scrollUp(40));
+        assertThat(firstVisibleRow, is(inSyncWithTable(tableView)));
     }
 
     private Duration measure(Runnable operation) {
@@ -206,8 +225,9 @@ public class TableView2Test extends FxRobot {
     }
 
     private void changeSelection() {
-        final TableView.TableViewSelectionModel<Row> sm = tableView.getSelectionModel();
-        final TableColumn<Row, ?> column = tableView.getColumns().get(0);
+        final TableView.TableViewSelectionModel<RowItem> sm = tableView.getSelectionModel();
+        final TableColumn<RowItem, ?> column = tableView.getColumns()
+                .get(0);
         // back and forth
         for (int i = 0; i < NUMBER_OF_SELECTION_CHANGES; i++) {
             final int selectedIndex = i % 2;
@@ -215,25 +235,69 @@ public class TableView2Test extends FxRobot {
         }
     }
 
-    private void scrollVertical() {
+    private void scrollDownAndUp() {
+        this.scrollDown(NUMBER_OF_SELECTION_CHANGES);
+        this.scrollUp(NUMBER_OF_SELECTION_CHANGES);
+    }
+
+    private void scrollDown(int times) {
         ScrollBar scrollBar = (ScrollBar) tableView.queryAccessibleAttribute(AccessibleAttribute.VERTICAL_SCROLLBAR);
-        // scroll down
-        for (int i = 0; i < NUMBER_OF_SELECTION_CHANGES; i++) {
+        for (int i = 0; i < times; i++) {
             final double value = i * 0.01;
-            interact(() -> {
-                scrollBar.setValue(value);
-            });
+            interact(() -> scrollBar.setValue(value));
         }
 
-        // clear creation count
-        numberRowChildrenModifications.set(0);
+    }
 
-        // scroll up
-        for (int i = NUMBER_OF_SELECTION_CHANGES; i >=0; i--) {
+    private void scrollUp(int times) {
+        ScrollBar scrollBar = (ScrollBar) tableView.queryAccessibleAttribute(AccessibleAttribute.VERTICAL_SCROLLBAR);
+        for (int i = times; i >= 0; i--) {
             final double value = i * 0.01;
-            interact(() -> {
-                scrollBar.setValue(value);
-            });
+            interact(() -> scrollBar.setValue(value));
         }
+    }
+
+    private static Matcher<TableRow2<?>> inSyncWithTable(TableView2<RowItem> tableView) {
+        return new BaseMatcher<>() {
+
+            private int firstMismatch = -1;
+            private Object expected = null;
+            private Object actual = null;
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("that cell at index " + firstMismatch + " contains ");
+                description.appendValue(expected);
+            }
+
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                description.appendText("cell at index " + firstMismatch + " contains ");
+                description.appendValue(actual);
+            }
+
+            @Override
+            public boolean matches(Object unknown) {
+                TableRow2<?> tableRow = (TableRow2<?>) unknown;
+                RowItem item = tableView.getItems()
+                        .get(tableRow.getIndex());
+                List<Node> children = new ArrayList<>(tableRow.getChildrenUnmodifiable());
+                for (Node child : children) {
+                    if (child instanceof TableCell) {
+                        TableCell<?, ?> cell = (TableCell<?, ?>) child;
+                        int index = Integer.parseInt(cell.getTableColumn()
+                                .getId()
+                                .split("_")[1]);
+                        actual = cell.getText();
+                        expected = item.values[index].get();
+                        if (!Objects.equals(actual, expected)) {
+                            firstMismatch = index;
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+        };
     }
 }

--- a/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
@@ -1,0 +1,158 @@
+package org.controlsfx.control.tableview2;
+
+import impl.org.controlsfx.tableview2.TableRow2;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.Scene;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.stage.Stage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static junit.framework.TestCase.assertNotNull;
+
+public class TableView2Test extends FxRobot {
+
+    private static class Row {
+        public final SimpleStringProperty[] values;
+
+        public Row(int rowIndex, int columnCount) {
+            values = new SimpleStringProperty[columnCount];
+            for (int i = 0; i < this.values.length; i++) {
+                this.values[i] = new SimpleStringProperty(rowIndex + "x" + i);
+            }
+        }
+    }
+
+
+    private static final int THREADS = 4;
+    private static final int NUMBER_OF_ROWS = 100;
+    private static final int NUMBER_OF_COLUMNS = 500;
+
+    private Stage stage;
+
+    private TableView2<Row> tableView;
+    private AtomicBoolean allowedToRun;
+    private ExecutorService dataManipulators;
+    private CountDownLatch dataManipulationCountdown;
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
+
+    @Before
+    public void beforeEach() throws TimeoutException {
+        stage = FxToolkit.registerPrimaryStage();
+        stage.setMaxHeight(600);
+        stage.setMaxWidth(800);
+        tableView = new TableView2<>();
+        dataManipulators = Executors.newFixedThreadPool(THREADS);
+
+        populateTable();
+        setupManipulators();
+
+        this.interact(() -> {
+            stage.setScene(new Scene(tableView));
+            stage.show();
+            stage.toFront();
+        });
+    }
+
+    private void setupManipulators() {
+        dataManipulationCountdown = new CountDownLatch(1);
+        allowedToRun = new AtomicBoolean(true);
+        for (int i = 0; i < THREADS; i++) {
+            this.dataManipulators.submit(() -> {
+                Random random = new SecureRandom();
+
+                try {
+                    dataManipulationCountdown.await();
+                } catch (InterruptedException e) {
+                    // return silently
+                    return;
+                }
+                while (allowedToRun.get()) {
+                    Row row = tableView.getItems().get(random.nextInt(NUMBER_OF_ROWS));
+                    row.values[random.nextInt(row.values.length)].set((100 + random.nextInt(100)) + "");
+                }
+            });
+        }
+    }
+
+    private void populateTable() {
+        tableView.rowFactoryProperty()
+                .unbind();
+        tableView.setRowFactory(param -> new TableRow2<>(tableView));
+        tableView.getItems()
+                .setAll(IntStream.range(0, NUMBER_OF_ROWS)
+                        .mapToObj((int rowIndex) -> new Row(rowIndex, NUMBER_OF_COLUMNS))
+                        .collect(Collectors.toList()));
+        List<TableColumn<Row, String>> fixed = new ArrayList<>();
+        tableView.getColumns()
+                .setAll(IntStream.range(0, NUMBER_OF_COLUMNS)
+                        .mapToObj(index -> {
+                            TableColumn<Row, String> column = new TableColumn<>();
+                            column.setId("column_" + index);
+                            column.setText("#" + index);
+                            column.setCellValueFactory(param -> param.getValue().values[index]);
+                            if (index < 3) {
+                                fixed.add(column);
+                            }
+                            return column;
+                        })
+                        .collect(Collectors.toList()));
+        tableView.getFixedColumns()
+                .setAll(fixed);
+    }
+
+    @After
+    public void afterEach() throws TimeoutException {
+        allowedToRun.set(false);
+        dataManipulators.shutdownNow();
+        FxToolkit.cleanupStages();
+    }
+
+    private void produceUpdateLoad() {
+        dataManipulationCountdown.countDown();
+    }
+
+    private void changeSelection() {
+        final TableView.TableViewSelectionModel<Row> sm = tableView.getSelectionModel();
+        final TableColumn<Row, ?> column = tableView.getColumns().get(0);
+        // back and forth
+        final int times = 20;
+        Phaser phaser = new Phaser();
+        phaser.bulkRegister(times + 1);
+        for (int i = 0; i < times; i++) {
+            final int selectedIndex = i % 2;
+            this.interact(() -> {
+                sm.clearAndSelect(selectedIndex, column);
+                phaser.arriveAndDeregister();
+            });
+        }
+        phaser.arriveAndAwaitAdvance();
+    }
+
+    @Test
+    public void shouldNotFreeze_When_SelectionIsChangedUnderLoad() {
+        produceUpdateLoad();
+
+        changeSelection();
+
+        assertNotNull(tableView.getSelectionModel()
+                .getSelectedItem());
+    }
+}

--- a/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
@@ -44,6 +44,9 @@ public class TableView2Test extends FxRobot {
         }
     }
 
+    private static final int TABLE_WIDTH = 800;
+    private static final int TABLE_HEIGHT = 600;
+
     private static final int THREADS = 4;
     private static final int NUMBER_OF_ROWS = 100;
     private static final int NUMBER_OF_COLUMNS = 500;
@@ -63,14 +66,17 @@ public class TableView2Test extends FxRobot {
     @Before
     public void beforeEach() throws TimeoutException {
         tableView = new TableView2<>();
+        tableView.setMaxWidth(TABLE_WIDTH);
+        tableView.setMaxHeight(TABLE_HEIGHT);
+        tableView.setPrefSize(TABLE_WIDTH,TABLE_HEIGHT);
         dataManipulators = Executors.newFixedThreadPool(THREADS);
 
         populateTable();
         setupManipulators();
 
         FxToolkit.setupStage(stage -> {
-            stage.setMaxHeight(600);
             stage.setMaxWidth(800);
+            stage.setMaxHeight(600);
             stage.setScene(new Scene(tableView));
             stage.show();
             stage.toFront();


### PR DESCRIPTION
Fixes #1361 

The non-responsiveness came from continuous listener adding while creating the cell that is not visible and be garbage collected immediately. Moving the getCell(..) call further down to be performed after the visibility check is avoiding unnessesary creation of elements.