### PR TITLE
Fix notifications

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/NotificationBar.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/NotificationBar.java
@@ -152,10 +152,8 @@ public abstract class NotificationBar extends Region {
         closeBtn.setFocusTraversable(false);
         closeBtn.opacityProperty().bind(transition);
         GridPane.setMargin(closeBtn, new Insets(0, 0, 0, 8));
-        
-        // position the close button in the best place, depending on the height
-        double minHeight = minHeight(-1);
-        GridPane.setValignment(closeBtn, minHeight == MIN_HEIGHT ? VPos.CENTER : VPos.TOP);
+
+        GridPane.setValignment(closeBtn, VPos.TOP);
         
         // put it all together
         updatePane();

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/NotificationBar.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/NotificationBar.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2015 ControlsFX
+ * Copyright (c) 2014, 2021 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/org/controlsfx/control/Notifications.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/Notifications.java
@@ -484,6 +484,7 @@ public class Notifications {
                 }
             };
 
+            notificationBar.setMinWidth(400);
             notificationBar.getStyleClass().addAll(notificationToShow.styleClass);
 
             notificationBar.setOnMouseClicked(e -> {

--- a/controlsfx/src/main/java/org/controlsfx/control/Notifications.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/Notifications.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2019, ControlsFX
+ * Copyright (c) 2014, 2021, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/org/controlsfx/control/Notifications.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/Notifications.java
@@ -442,26 +442,6 @@ public class Notifications {
                 }
 
                 @Override
-                protected double computeMinWidth(double height) {
-                    String text = getText();
-                    Node graphic = getGraphic();
-                    if ((text == null || text.isEmpty()) && (graphic != null)) {
-                        return graphic.minWidth(height);
-                    }
-                    return 400;
-                }
-
-                @Override
-                protected double computeMinHeight(double width) {
-                    String text = getText();
-                    Node graphic = getGraphic();
-                    if ((text == null || text.isEmpty()) && (graphic != null)) {
-                        return graphic.minHeight(width);
-                    }
-                    return 100;
-                }
-
-                @Override
                 public boolean isShowFromTop() {
                     return NotificationPopupHandler.this.isShowFromTop(notificationToShow.position);
                 }


### PR DESCRIPTION
Simplified various places in the code.
I think the minHeight is not required, the content should provide the minimum height.
The computeMinHeight/Width methods caused issues. They also were illogical, because graphic is only a small part of it's content.

After this change it seems to work again.

Without this change, and when the graphic is set (for example with .graphic(new Label(text)) )
Then it looked like the following:

<img width="387" alt="Screenshot 2021-05-18 at 10 55 31" src="https://user-images.githubusercontent.com/6547435/118622399-93254400-b7c7-11eb-8f7f-370d1b5abda9.png">

I've also removed the VPos logic, because it now always positions it in the center, and it also doesn't really make sense to me.
