### PR TITLE
Action.setSelected(boolean) now triggers the EventHandler if needed,

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/action/Action.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/action/Action.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2015, ControlsFX
+ * Copyright (c) 2013, 2021 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -189,11 +189,15 @@ public class Action implements EventHandler<ActionEvent> {
      * Sets selected state of the Action
      * @param selected
      */
-    public final void setSelected( boolean selected ) {
-    	selectedProperty.set(selected);
+    public final void setSelected(boolean selected) {
+        if (isSelected() != selected) {
+            selectedProperty.set(selected);
+            if (getClass().isAnnotationPresent(ActionCheck.class)) {
+                eventHandler.accept(null);
+            }
+        }
     }
-    
-    
+
     // --- text
     private final StringProperty textProperty = new SimpleLocalizedStringProperty(this, "text"){ //$NON-NLS-1$
     	@Override public void set(String value) {


### PR DESCRIPTION
Hi,

Using org.controlsfx.control.action.Action.setSelected(boolean) changes the selected state of ActionCheck actions correctly but does not trigger the corresponding EventHandler. 

So, changing the state programmatically, using this method, does not make the application do what it would when clicking  toogleButton or checkMenu elements created with the ActionCheck (activate or deactivate the rendering of an animation for instance)