### PR TITLE
Allow SpreadsheetView CSS to be overridden

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/SpreadsheetGridView.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/SpreadsheetGridView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2014, 2015 ControlsFX
+ * Copyright (c) 2013, 2021 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,11 +36,6 @@ import org.controlsfx.control.spreadsheet.SpreadsheetView;
 public class SpreadsheetGridView extends TableView<ObservableList<SpreadsheetCell>> {
     private final SpreadsheetHandle handle;
 
-    /*
-     * cache the stylesheet as lookup takes time and the getUserAgentStylesheet is called repeatedly
-     */
-    private String stylesheet;
-
     /**
      * We don't want to show the current value in the TextField when we are
      * editing by typing a key. We want directly to take those typed letters
@@ -52,14 +47,7 @@ public class SpreadsheetGridView extends TableView<ObservableList<SpreadsheetCel
 
     @Override
     public String getUserAgentStylesheet() {
-        /*
-         * For more information please see RT-40658
-         */
-        if (stylesheet == null) {
-            stylesheet = SpreadsheetView.class.getResource("spreadsheet.css") //$NON-NLS-1$
-                    .toExternalForm();
-        }
-        return stylesheet;
+        return handle.getView().getUserAgentStylesheet();
     }
 
     @Override

--- a/controlsfx/src/main/java/org/controlsfx/control/spreadsheet/SpreadsheetView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/spreadsheet/SpreadsheetView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2019 ControlsFX
+ * Copyright (c) 2013, 2021 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -419,6 +419,9 @@ public class SpreadsheetView extends Control{
     private SortedList<ObservableList<SpreadsheetCell>> sortedList;
     private CellGraphicFactory cellGraphicFactory;
 
+    //Cache the stylesheet as lookup takes time and the getUserAgentStylesheet is called repeatedly
+    private String stylesheet;
+
     /**
      * Since the default with applied to TableColumn is 80. If a user sets a
      * width of 80, the column will be detected as having the default with and
@@ -464,6 +467,19 @@ public class SpreadsheetView extends Control{
      */
     final SpreadsheetGridView getCellsView() {
         return cellsView;
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        /*
+         * For more information please see RT-40658
+         */
+        if (stylesheet == null) {
+            stylesheet = SpreadsheetView.class.getResource("spreadsheet.css") //$NON-NLS-1$
+                    .toExternalForm();
+        }
+
+        return stylesheet;
     }
     
     /**


### PR DESCRIPTION
Applies changes discussed in https://github.com/controlsfx/controlsfx/issues/957
fix #957 