### PR TITLE
Fixed bug where high thumb & rangeBar missing

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/RangeSliderSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/RangeSliderSkin.java
@@ -111,9 +111,11 @@ public class RangeSliderSkin extends SkinBase<RangeSlider> {
         });
         registerChangeListener(rangeSlider.showTickMarksProperty(), e -> {
             setShowTickMarks(getSkinnable().isShowTickMarks(), getSkinnable().isShowTickLabels());
+            readdHighThumbAndRangeBar();
         });
         registerChangeListener(rangeSlider.showTickLabelsProperty(), e -> {
             setShowTickMarks(getSkinnable().isShowTickMarks(), getSkinnable().isShowTickLabels());
+            readdHighThumbAndRangeBar();
         });
         registerChangeListener(rangeSlider.majorTickUnitProperty(), e -> {
             if (tickLine != null) {
@@ -346,6 +348,13 @@ public class RangeSliderSkin extends SkinBase<RangeSlider> {
         }
 
         getSkinnable().requestLayout();
+    }
+    
+    private void readdHighThumbAndRangeBar() {
+	if (!getChildren().contains(highThumb))
+	    getChildren().add(highThumb);
+	if (!getChildren().contains(rangeBar))
+	    getChildren().add(rangeBar);
     }
 
     /**


### PR DESCRIPTION
Hi,
This PR fix a bug where the high thumb and range bar are missing in RangeSlider when you change the tick marks / labels visibility
I think the problem culprit is here: https://github.com/controlsfx/controlsfx/blob/b0cec184fb62395cc51edd39a3790e7589f467a9/controlsfx/src/main/java/impl/org/controlsfx/skin/RangeSliderSkin.java#L314
The method documentation says: "After this method, we must be sure to add the high Thumb and the rangeBar." but I don't see any code line which does that.
It worked fine with 8.40.16 though