### PR TITLE
Add missing JavaDoc for Dialog classes

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/dialog/CommandLinksDialog.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/CommandLinksDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2015 ControlsFX
+ * Copyright (c) 2014, 2022 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,8 +49,31 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 
+/**
+ * <p>{@link Dialog} containing command links.</p>
+ * Command links are similar to radio buttons. They are used to select
+ * from a set of mutually exclusive, related choices.<br>
+ * Like radio buttons, command links are always presented in sets, never individually.<br>
+ * Usage example:
+ * <ol>
+ * <li>Create a list of {@link CommandLinksButtonType command link buttons} that represent the different choices:
+ * <pre>{@code CommandLinksButtonType restartLink = new CommandLinksButtonType("Restart the program", false);
+ * CommandLinksButtonType closeLink = new CommandLinksButtonType("Close the program", false);
+ * CommandLinksButtonType waitLink = new CommandLinksButtonType("Wait for the program to respond",
+ * "This is the default option", true);
+ * List<CommandLinksButtonType> links = Arrays.asList(restartLink, closeLink, waitLink);}</pre></li>
+ * <li>Initialize the dialog with the list of command link buttons:
+ * <pre>{@code CommandLinksDialog dialog = new CommandLinksDialog(links);}</pre></li>
+ * <li>Add dialog title and header content text as appropriate:
+ * <pre>{@code dialog.setTitle("Microsoft Windows");
+ * dialog.getDialogPane().setContentText("Windows Explorer is not responding");}</pre></li>
+ * </ol>
+ */
 public class CommandLinksDialog extends Dialog<ButtonType> {
     
+    /**
+     * <p>Command link type buttons to be used in {@link CommandLinksDialog}s.</p>
+     */
     public static class CommandLinksButtonType {
         private final ButtonType buttonType;
         private final String longText;

--- a/controlsfx/src/main/java/org/controlsfx/dialog/ExceptionDialog.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/ExceptionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2019 ControlsFX
+ * Copyright (c) 2014, 2022 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,14 @@ import javafx.scene.control.TextArea;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 
+/**
+ * {@link Dialog} with exception details.<br>
+ * Usage: Simply pass a {@link Throwable} and the dialog will display:<br>
+ * <ul>
+ *     <li>The exception message</li>
+ *     <li>The full exception stack trace in an expandable TextArea.</li>
+ * </ul>
+ */
 public class ExceptionDialog extends Dialog<ButtonType> {
 
     public ExceptionDialog(final Throwable exception) {

--- a/controlsfx/src/main/java/org/controlsfx/dialog/FontSelectorDialog.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/FontSelectorDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 ControlsFX
+ * Copyright (c) 2014, 2022 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -61,6 +61,11 @@ import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
 import javafx.util.Callback;
 
+/**
+ * {@link Dialog} for selecting and previewing fonts.<br>
+ * The list of fonts will contain all the font families installed on the user's system,
+ * as per JavaFX {@link Font#getFamilies()}.
+ */
 public class FontSelectorDialog extends Dialog<Font> {
     
     private FontPanel fontPanel;

--- a/controlsfx/src/main/java/org/controlsfx/dialog/LoginDialog.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/LoginDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2015 ControlsFX
+ * Copyright (c) 2014, 2022 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,10 @@ import org.controlsfx.control.textfield.TextFields;
 import org.controlsfx.validation.ValidationSupport;
 import org.controlsfx.validation.Validator;
 
+/**
+ * User login {@link Dialog} with a username and a password field.<br>
+ * The input fields are clearable by default (can be emptied with a button).
+ */
 public class LoginDialog extends Dialog<Pair<String,String>> {
     
     private final ButtonType loginButtonType;

--- a/controlsfx/src/main/java/org/controlsfx/dialog/ProgressDialog.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/ProgressDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2015 ControlsFX
+ * Copyright (c) 2014, 2022 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,10 @@ import javafx.scene.control.ProgressBar;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
+/**
+ * Progress {@link Dialog} to report on the progress of any background {@link Worker}.<br>
+ * After the given {@link Worker} finishes, the Progress Dialog automatically closes.
+ */
 public class ProgressDialog extends Dialog<Void> {
     
 


### PR DESCRIPTION
Fixes #1162
Added documentation with usage examples for: CommandLinksDialog, CommandLinksButtonType
and descriptions for: ExceptionDialog, FontSelectorDialog, LoginDialog, ProgressDialog.