### PR TITLE
Create primitive type wrapper objects without a constructor

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/property/editor/Editors.java
+++ b/controlsfx/src/main/java/org/controlsfx/property/editor/Editors.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2021, ControlsFX
+ * Copyright (c) 2015, 2022, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,8 @@ package org.controlsfx.property.editor;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Optional;
@@ -87,6 +89,24 @@ public class Editors {
             }
 
             @Override public Number getValue() {
+                if (sourceClass == Byte.class) {
+                    return Byte.valueOf(getEditor().getText());
+                } else if (sourceClass == Short.class) {
+                    return Short.valueOf(getEditor().getText());
+                } else if (sourceClass == Integer.class) {
+                    return Integer.valueOf(getEditor().getText());
+                } else if (sourceClass == Long.class) {
+                    return Long.valueOf(getEditor().getText());
+                } else if (sourceClass == Float.class) {
+                    return Float.valueOf(getEditor().getText());
+                } else if (sourceClass == Double.class) {
+                    return Double.valueOf(getEditor().getText());
+                } else if (sourceClass == BigInteger.class) {
+                    return new BigInteger(getEditor().getText());
+                } else if (sourceClass == BigDecimal.class) {
+                    return new BigDecimal(getEditor().getText());
+                }
+
                 try {
                     return sourceClass.getConstructor(String.class).newInstance(getEditor().getText());
                 } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException


### PR DESCRIPTION
Constructors of wrapper classes for primitive types are deprecated  for removal in Java 16 (see [JEP 390](https://openjdk.java.net/jeps/390)). They should be removed when [JEP 402](https://openjdk.java.net/jeps/402) is done.

Right now `Editors.createNumericEditor` is still using reflection to call their constructors to create objects, which makes it impossible to work with Valhalla, and we should avoid that.
