### PR TITLE
Remove event filter when owner window is hiding 

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
@@ -153,8 +153,11 @@ public class PopOver extends PopupControl {
     }
 
     /**
+     * Adds the EventFilter when the WindowProperty changes.
+     * Solves the issue (#1441) that leads to an exception, when closing the window (using the "x"-button) while the PopOver is visible.
      *
-     *
+     * Hint: This seems to be needed additional to filters that are already implemented in {@link #show(Window)}, {@link #hide(Duration)}...
+     * It also doesn't work when using the WeakEventHandler instead. Replacing the Handlers in the other positions also doesn't lead to success.
      */
     private void setUpOwnerCloseBehaviour() {
         ownerWindowProperty().addListener((o) -> {

--- a/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
@@ -164,9 +164,6 @@ public class PopOver extends PopupControl {
             if (getOwnerWindow() != null) {
                 getOwnerWindow().addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, closePopOverOnOwnerWindowCloseLambda);
                 getOwnerWindow().addEventFilter(WindowEvent.WINDOW_HIDING, closePopOverOnOwnerWindowCloseLambda);
-            }else{
-                getOwnerWindow().removeEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, closePopOverOnOwnerWindowCloseLambda);
-                getOwnerWindow().removeEventFilter(WindowEvent.WINDOW_HIDING, closePopOverOnOwnerWindowCloseLambda);
             }
         });
     }
@@ -534,6 +531,10 @@ public class PopOver extends PopupControl {
                     closePopOverOnOwnerWindowClose);
             ownerWindow.removeEventFilter(WindowEvent.WINDOW_HIDING,
                 closePopOverOnOwnerWindowClose);
+            ownerWindow.removeEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST,
+                    closePopOverOnOwnerWindowCloseLambda);
+            ownerWindow.removeEventFilter(WindowEvent.WINDOW_HIDING,
+                    closePopOverOnOwnerWindowCloseLambda);
         }
         if (fadeOutDuration == null) {
             fadeOutDuration = DEFAULT_FADE_DURATION;

--- a/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
@@ -115,14 +115,8 @@ public class PopOver extends PopupControl {
             }
         });
 
-        ownerWindowProperty().addListener((o) -> {
-            if (getOwnerWindow() != null) {
-                getOwnerWindow().setOnCloseRequest((t) -> {
-                    hide(Duration.ZERO);
-                });
-            }
-        });
-        
+        setUpOwnerCloseBehaviour();
+
         /*
          * Create some initial content.
          */
@@ -156,6 +150,22 @@ public class PopOver extends PopupControl {
         });
 
         setAutoHide(true);
+    }
+
+    /**
+     *
+     *
+     */
+    private void setUpOwnerCloseBehaviour() {
+        ownerWindowProperty().addListener((o) -> {
+            if (getOwnerWindow() != null) {
+                getOwnerWindow().addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, closePopOverOnOwnerWindowCloseLambda);
+                getOwnerWindow().addEventFilter(WindowEvent.WINDOW_HIDING, closePopOverOnOwnerWindowCloseLambda);
+            }else{
+                getOwnerWindow().removeEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, closePopOverOnOwnerWindowCloseLambda);
+                getOwnerWindow().removeEventFilter(WindowEvent.WINDOW_HIDING, closePopOverOnOwnerWindowCloseLambda);
+            }
+        });
     }
 
     /**

--- a/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2016 ControlsFX
+ * Copyright (c) 2013, 2022, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
@@ -293,7 +293,6 @@ public class PopOver extends PopupControl {
 
     private Window ownerWindow;
     private final EventHandler<WindowEvent> closePopOverOnOwnerWindowCloseLambda = event -> ownerWindowClosing();
-    private final WeakEventHandler<WindowEvent> closePopOverOnOwnerWindowClose = new WeakEventHandler<>(closePopOverOnOwnerWindowCloseLambda);
 
     /**
      * Shows the pop over in a position relative to the edges of the given owner
@@ -364,15 +363,10 @@ public class PopOver extends PopupControl {
     public final void show(Window owner) {
         super.show(owner);
         ownerWindow = owner;
-
         if (isAnimated()) {
             showFadeInAnimation(getFadeInDuration());
         }
 
-        ownerWindow.addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST,
-                closePopOverOnOwnerWindowClose);
-        ownerWindow.addEventFilter(WindowEvent.WINDOW_HIDING,
-                closePopOverOnOwnerWindowClose);
     }
 
     /** {@inheritDoc} */
@@ -385,10 +379,6 @@ public class PopOver extends PopupControl {
             showFadeInAnimation(getFadeInDuration());
         }
 
-        ownerWindow.addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST,
-                closePopOverOnOwnerWindowClose);
-        ownerWindow.addEventFilter(WindowEvent.WINDOW_HIDING,
-                closePopOverOnOwnerWindowClose);
     }
 
     /**
@@ -488,11 +478,6 @@ public class PopOver extends PopupControl {
             showFadeInAnimation(fadeInDuration);
         }
 
-        // Bug fix - close popup when owner window is closing
-        ownerWindow.addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST,
-                closePopOverOnOwnerWindowClose);
-        ownerWindow.addEventFilter(WindowEvent.WINDOW_HIDING,
-                closePopOverOnOwnerWindowClose);
     }
 
     private void showFadeInAnimation(Duration fadeInDuration) {
@@ -530,12 +515,6 @@ public class PopOver extends PopupControl {
      */
     public final void hide(Duration fadeOutDuration) {
         //We must remove EventFilter in order to prevent memory leak.
-        if (ownerWindow != null){
-            ownerWindow.removeEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST,
-                    closePopOverOnOwnerWindowClose);
-            ownerWindow.removeEventFilter(WindowEvent.WINDOW_HIDING,
-                closePopOverOnOwnerWindowClose);
-        }
         if (fadeOutDuration == null) {
             fadeOutDuration = DEFAULT_FADE_DURATION;
         }

--- a/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
@@ -531,10 +531,6 @@ public class PopOver extends PopupControl {
                     closePopOverOnOwnerWindowClose);
             ownerWindow.removeEventFilter(WindowEvent.WINDOW_HIDING,
                 closePopOverOnOwnerWindowClose);
-            ownerWindow.removeEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST,
-                    closePopOverOnOwnerWindowCloseLambda);
-            ownerWindow.removeEventFilter(WindowEvent.WINDOW_HIDING,
-                    closePopOverOnOwnerWindowCloseLambda);
         }
         if (fadeOutDuration == null) {
             fadeOutDuration = DEFAULT_FADE_DURATION;

--- a/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
@@ -160,10 +160,14 @@ public class PopOver extends PopupControl {
      * It also doesn't work when using the WeakEventHandler instead. Replacing the Handlers in the other positions also doesn't lead to success.
      */
     private void setUpOwnerCloseBehaviour() {
-        ownerWindowProperty().addListener((o) -> {
-            if (getOwnerWindow() != null) {
-                getOwnerWindow().addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, closePopOverOnOwnerWindowCloseLambda);
-                getOwnerWindow().addEventFilter(WindowEvent.WINDOW_HIDING, closePopOverOnOwnerWindowCloseLambda);
+        ownerWindowProperty().addListener((o, oldVal, newVal) -> {
+            if (oldVal != null) {
+                oldVal.removeEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, closePopOverOnOwnerWindowCloseLambda);
+                oldVal.removeEventFilter(WindowEvent.WINDOW_HIDING, closePopOverOnOwnerWindowCloseLambda);
+            }
+            if (newVal != null) {
+                newVal.addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, closePopOverOnOwnerWindowCloseLambda);
+                newVal.addEventFilter(WindowEvent.WINDOW_HIDING, closePopOverOnOwnerWindowCloseLambda);
             }
         });
     }

--- a/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/PopOver.java
@@ -115,6 +115,14 @@ public class PopOver extends PopupControl {
             }
         });
 
+        ownerWindowProperty().addListener((o) -> {
+            if (getOwnerWindow() != null) {
+                getOwnerWindow().setOnCloseRequest((t) -> {
+                    hide(Duration.ZERO);
+                });
+            }
+        });
+        
         /*
          * Create some initial content.
          */


### PR DESCRIPTION
As Described under https://github.com/controlsfx/controlsfx/issues/1441
The Error on Window closing while a PopOver is open is caused by the fadeout time.
Can be fixed by adding a OnCloseRequest-listener to the OwnerWindow which then closes the PopOver without delay.