### PR TITLE
Allow the developer to specify that the source and target lists should be sorted.

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/ListSelectionView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/ListSelectionView.java
@@ -477,6 +477,11 @@ public class ListSelectionView<T> extends ControlsFXControl {
     }
     
     private Comparator<T> comparator;
+    
+    /**
+     * Set a comparator to ensure that the source and target items list is sorted
+     * @param comparator the comparator to use to sort the source and target items.
+     */
     public void setComparator(Comparator<T> comparator) {
         this.comparator = comparator;
     }

--- a/controlsfx/src/main/java/org/controlsfx/control/ListSelectionView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/ListSelectionView.java
@@ -47,6 +47,7 @@ import org.controlsfx.glyphfont.FontAwesome;
 import org.controlsfx.glyphfont.Glyph;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -474,6 +475,17 @@ public class ListSelectionView<T> extends ControlsFXControl {
             super.setEventHandler(eventHandler);
         }
     }
+    
+    private Comparator<T> comparator;
+    public void setComparator(Comparator<T> comparator) {
+        this.comparator = comparator;
+    }
+    private void sortItems(ListView<T> sourceListView, ListView<T> targetListView) {
+        if (comparator != null) {
+            sourceListView.getItems().sort(comparator);
+            targetListView.getItems().sort(comparator);
+        }
+    }
 
     /**
      * Action use to move the selected items from the
@@ -492,7 +504,10 @@ public class ListSelectionView<T> extends ControlsFXControl {
         @Override
         public void initialize(ListView<T> sourceListView, ListView<T> targetListView) {
             disabledProperty().bind(Bindings.isEmpty(sourceListView.getSelectionModel().getSelectedItems()));
-            setEventHandler(ae -> moveToTarget(sourceListView, targetListView));
+            setEventHandler(ae -> {
+                moveToTarget(sourceListView, targetListView);
+                sortItems(sourceListView, targetListView);
+            });
         }
     }
 
@@ -513,7 +528,10 @@ public class ListSelectionView<T> extends ControlsFXControl {
         @Override
         public void initialize(ListView<T> sourceListView, ListView<T> targetListView) {
             disabledProperty().bind(Bindings.isEmpty(sourceListView.getItems()));
-            setEventHandler(ae -> moveToTargetAll(sourceListView, targetListView));
+            setEventHandler(ae -> {
+                moveToTargetAll(sourceListView, targetListView);
+                sortItems(sourceListView, targetListView);
+            });
         }
     }
 
@@ -534,7 +552,10 @@ public class ListSelectionView<T> extends ControlsFXControl {
         @Override
         public void initialize(ListView<T> sourceListView, ListView<T> targetListView) {
             disabledProperty().bind(Bindings.isEmpty(targetListView.getSelectionModel().getSelectedItems()));
-            setEventHandler(ae -> moveToSource(sourceListView, targetListView));
+            setEventHandler(ae -> {
+                moveToSource(sourceListView, targetListView);
+                sortItems(sourceListView, targetListView);
+            });
         }
     }
 
@@ -555,7 +576,10 @@ public class ListSelectionView<T> extends ControlsFXControl {
         @Override
         public void initialize(ListView<T> sourceListView, ListView<T> targetListView) {
             disabledProperty().bind(Bindings.isEmpty(targetListView.getItems()));
-            setEventHandler(ae -> moveToSourceAll(sourceListView, targetListView));
+            setEventHandler(ae -> {
+                moveToSourceAll(sourceListView, targetListView);
+                sortItems(sourceListView, targetListView);
+            });
         }
     }
 


### PR DESCRIPTION
When a user moves an item from the source list to the target list, or vice versa. The item always appears at the end of the destination list. This can sometimes be undesirable behaviour e.g. if the destination list is very long, then it might not be obvious that the item has arrived. 

I think that it would be useful to allow the developer to set a sort order on the lists so that it should be easier for the user to find things and more obvious when they have added / removed entries.
