### PR TITLE
Fixing two resource bugs within the sample application. 

### DIFF
--- a/controlsfx-samples/src/main/java/org/controlsfx/samples/HelloHyperlinkLabel.java
+++ b/controlsfx-samples/src/main/java/org/controlsfx/samples/HelloHyperlinkLabel.java
@@ -96,8 +96,7 @@ public class HelloHyperlinkLabel extends ControlsFXSample {
             selectedLinkField.setText(str);
         });
         root.getChildren().add(label);
-        root.getStylesheets().add(getClass().getResource("/style.css").toExternalForm());
-        
+
         return root;
     }
 

--- a/controlsfx-samples/src/main/java/org/controlsfx/samples/dialogs/HelloDialogs.java
+++ b/controlsfx-samples/src/main/java/org/controlsfx/samples/dialogs/HelloDialogs.java
@@ -399,9 +399,9 @@ public class HelloDialogs extends ControlsFXSample {
         if (header != null && cbShowMasthead.isSelected()) {
             dlg.getDialogPane().setHeaderText(header);
         }
-        
+
         if (cbCustomGraphic.isSelected()) {
-            dlg.getDialogPane().setGraphic(new ImageView(new Image(getClass().getResource("../controlsfx-logo.png").toExternalForm())));
+            dlg.getDialogPane().setGraphic(new ImageView(new Image(getClass().getResource("/org/controlsfx/samples/controlsfx-logo.png").toExternalForm())));
         }
         
         dlg.initStyle(styleCombobox.getValue());


### PR DESCRIPTION
Fixing two resource bugs within the sample application. 

1. HelloHyperlinkLabel was looking for a style.css file that does not exist anywhere (and is probably not necessary). 

2. HelloDialogs was attempting to refer to a parent directory; but this doesn't work as the developer expected in the context of a running JAR. E.g., getResource("."), getResource(".."), getResource("../.."), etc., all resolve to null. This is not the case when running in a non-JAR context.

Easy to reproduce these using "gradle run" and trying to load the hyperlink demo, or the dialog pop with custom image demo; neither work currently.

Fixes #1527