### PR TITLE
Prevent possible NPE while dragging the thumbs of the RangeSlider control

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/RangeSliderSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/RangeSliderSkin.java
@@ -244,6 +244,9 @@ public class RangeSliderSkin extends SkinBase<RangeSlider> {
 
         lowThumb.setOnMouseDragged(me -> {
             Point2D cur = lowThumb.localToParent(me.getX(), me.getY());
+            if (preDragThumbPoint == null) {
+                preDragThumbPoint = cur;
+            }
             double dragPos = (isHorizontal())?
                 cur.getX() - preDragThumbPoint.getX() : -(cur.getY() - preDragThumbPoint.getY());
             lowThumbDragged(me, preDragPos + dragPos / trackLength);
@@ -269,6 +272,9 @@ public class RangeSliderSkin extends SkinBase<RangeSlider> {
             double trackLength = orientation ? track.getWidth() : track.getHeight();
 
             Point2D point2d = highThumb.localToParent(e.getX(), e.getY());
+            if (preDragThumbPoint == null) {
+                preDragThumbPoint = point2d;
+            }
             double d = getSkinnable().getOrientation() != Orientation.HORIZONTAL ? -(point2d.getY() - preDragThumbPoint.getY()) : point2d.getX() - preDragThumbPoint.getX();
             highThumbDragged(e, preDragPos + d / trackLength);
         });

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/RangeSliderSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/RangeSliderSkin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2021, ControlsFX
+ * Copyright (c) 2013, 2023, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Fixes #1506 

It is a very weird issue that shouldn't happen. But in that case, this PR simply adds a null check and sets `preDragThumbPoint` to the coordinates first drag event.