### PR TITLE
PropertyEditors now subscribe to the item's ObservableValue even if the editor is read-only

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/property/editor/AbstractPropertyEditor.java
+++ b/controlsfx/src/main/java/org/controlsfx/property/editor/AbstractPropertyEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, ControlsFX
+ * Copyright (c) 2023, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/org/controlsfx/property/editor/AbstractPropertyEditor.java
+++ b/controlsfx/src/main/java/org/controlsfx/property/editor/AbstractPropertyEditor.java
@@ -79,6 +79,17 @@ public abstract class AbstractPropertyEditor<T, C extends Node> implements Prope
     public AbstractPropertyEditor(Item property, C control, boolean readonly) {
         this.control = control;
         this.property = property;
+
+        if (property.getObservableValue().isPresent()) {
+            property.getObservableValue().get().addListener((ObservableValue<? extends Object> o, Object oldValue, Object newValue) -> {
+                if (! suspendUpdate) {
+                    suspendUpdate = true;
+                    AbstractPropertyEditor.this.setValue((T) property.getValue());
+                    suspendUpdate = false;
+                }
+            });
+        }
+
         if (! readonly) {
             getObservableValue().addListener((ObservableValue<? extends Object> o, Object oldValue, Object newValue) -> {
                 if (! suspendUpdate) {
@@ -87,17 +98,6 @@ public abstract class AbstractPropertyEditor<T, C extends Node> implements Prope
                     suspendUpdate = false;
                 }
             });
-            
-            if (property.getObservableValue().isPresent()) {
-                property.getObservableValue().get().addListener((ObservableValue<? extends Object> o, Object oldValue, Object newValue) -> {
-                    if (! suspendUpdate) {
-                        suspendUpdate = true;
-                        AbstractPropertyEditor.this.setValue((T) property.getValue());
-                        suspendUpdate = false;
-                    }
-                });
-            }
-            
         }
     }
     

--- a/controlsfx/src/main/java/org/controlsfx/property/editor/AbstractPropertyEditor.java
+++ b/controlsfx/src/main/java/org/controlsfx/property/editor/AbstractPropertyEditor.java
@@ -80,15 +80,13 @@ public abstract class AbstractPropertyEditor<T, C extends Node> implements Prope
         this.control = control;
         this.property = property;
 
-        if (property.getObservableValue().isPresent()) {
-            property.getObservableValue().get().addListener((ObservableValue<? extends Object> o, Object oldValue, Object newValue) -> {
-                if (! suspendUpdate) {
-                    suspendUpdate = true;
-                    AbstractPropertyEditor.this.setValue((T) property.getValue());
-                    suspendUpdate = false;
-                }
-            });
-        }
+        property.getObservableValue().ifPresent(obs -> obs.addListener((ObservableValue<?> o, Object oldValue, Object newValue) -> {
+            if (!suspendUpdate) {
+                suspendUpdate = true;
+                AbstractPropertyEditor.this.setValue((T) property.getValue());
+                suspendUpdate = false;
+            }
+        }));
 
         if (! readonly) {
             getObservableValue().addListener((ObservableValue<? extends Object> o, Object oldValue, Object newValue) -> {

--- a/controlsfx/src/main/java/org/controlsfx/property/editor/AbstractPropertyEditor.java
+++ b/controlsfx/src/main/java/org/controlsfx/property/editor/AbstractPropertyEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, ControlsFX
+ * Copyright (c) 2013, 2023, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Fixes issue #1511 