### PR TITLE
Provide a public getter method for the Dialog used by a Wizard

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/dialog/Wizard.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/Wizard.java
@@ -258,6 +258,16 @@ public class Wizard {
     public final ObservableMap<String, Object> getSettings() {
         return settings;
     }
+
+    /**
+     * Provides access to the {@link Dialog} object used to display the {@link Wizard}.
+     * @return The {@link Dialog} representing this {@link Wizard}. <br>
+     *         This can be accessed in order to modify its properties if necessary,
+     *         for example setting its window icon or its modality.
+     */
+    public final Dialog<ButtonType> getDialog() {
+        return dialog;
+    }
     
     
     
@@ -724,23 +734,6 @@ public class Wizard {
             int pageIndex = pages.indexOf(currentPage);
             return pages.size()-1 > pageIndex; 
         }
-    }
-    
-    
-    
-    /**************************************************************************
-     * 
-     * Methods for the sake of unit tests
-     * 
-     **************************************************************************/
-    
-    /**
-     * @return The {@link Dialog} representing this {@link Wizard}. <br>
-     *         This is actually for {@link Dialog} reading-purposes, e.g.
-     *         unit testing the {@link DialogPane} content.
-     */
-    Dialog<ButtonType> getDialog() {
-        return dialog;
     }
     
 }

--- a/controlsfx/src/main/java/org/controlsfx/dialog/Wizard.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/Wizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2018, 2024 ControlsFX
+ * Copyright (c) 2014, 2025, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/org/controlsfx/dialog/Wizard.java
+++ b/controlsfx/src/main/java/org/controlsfx/dialog/Wizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2018 ControlsFX
+ * Copyright (c) 2014, 2018, 2024 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I believe this provides the access necessary to resolve #756, #976, #999 and #1388.

I have chosen to make `getDialog()` public rather than alternative methods such as a `setDialog()` or making `dialog` itself protected as I believe this offers the simplest possible change to meet the needs of these issues (and my own).

I can't see any obvious disadvantage to making the Wizard dialog accessible in this way, but if there is some subtlety that I have missed, please let me know.