### PR TITLE
feat: Transfer the properties set on the actual SearchableComboxBox t…

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/SearchableComboBoxSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/SearchableComboBoxSkin.java
@@ -133,6 +133,9 @@ public class SearchableComboBoxSkin<T> extends SkinBase<ComboBox<T>> {
 
         // first create the filtered combo box
         filteredComboBox = createFilteredComboBox();
+
+        Bindings.bindContentBidirectional(comboBox.getProperties(), filteredComboBox.getProperties());
+
         getChildren().add(filteredComboBox);
 
         // and the search field

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/SearchableComboBoxSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/SearchableComboBoxSkin.java
@@ -133,9 +133,6 @@ public class SearchableComboBoxSkin<T> extends SkinBase<ComboBox<T>> {
 
         // first create the filtered combo box
         filteredComboBox = createFilteredComboBox();
-
-        Bindings.bindContentBidirectional(comboBox.getProperties(), filteredComboBox.getProperties());
-
         getChildren().add(filteredComboBox);
 
         // and the search field
@@ -193,6 +190,7 @@ public class SearchableComboBoxSkin<T> extends SkinBase<ComboBox<T>> {
 
         // bidirectional bindings
         box.valueProperty().bindBidirectional(getSkinnable().valueProperty());
+        Bindings.bindContentBidirectional(getSkinnable().getProperties(), filteredComboBox.getProperties());
 
         return box;
     }


### PR DESCRIPTION
Hi, I was playing around with a SearchableComboBox that had a lot of elements. This lead to very low performance, since the ComboBox was trying to figure out its preferred width based on all elements despite me telling it to only use a few cells (as suggested here: https://stackoverflow.com/questions/49930449/javafx-combobox-is-calling-listcell-updateitem-infinitely). Turns out, the properties set on the outer SearchableComboBox are not transferred to the delegate used in the skin. I try to rectify this in this PR.

Fixes https://github.com/controlsfx/controlsfx/issues/1603