### PR TITLE
BitSetReadOnlyUnbackedObservableList auto cache correction

### DIFF
--- a/controlsfx/src/main/java/org/controlsfx/control/CheckBitSetModelBase.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckBitSetModelBase.java
@@ -212,6 +212,7 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
         if (index < 0 || index >= getItemCount()) return;
         final int changeIndex = checkedIndicesList.indexOf(index);
         checkedIndices.clear(index);
+        checkedIndicesList.bitSetModified(index, false);
         checkedIndicesList.callObservers(new NonIterableChange.SimpleRemovedChange<>(changeIndex, changeIndex, index, checkedIndicesList));
     }
     
@@ -255,6 +256,7 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
     public void check(int index) {
         if (index < 0 || index >= getItemCount()) return;
         checkedIndices.set(index);
+        checkedIndicesList.bitSetModified(index, true);
         final int changeIndex = checkedIndicesList.indexOf(index);
         checkedIndicesList.callObservers(new NonIterableChange.SimpleAddChange<>(changeIndex, changeIndex+1, checkedIndicesList));
     }
@@ -400,6 +402,24 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
         public void reset() {
             this.lastGetIndex = -1;
             this.lastGetValue = -1;
+        }
+
+        public void bitSetModified(int index, boolean added) {
+            if (lastGetValue < 0) return;
+
+            if (added) {
+                if (index <= lastGetValue) {
+                    lastGetIndex++;
+                }
+            } else {
+                if (index < lastGetValue) {
+                    lastGetIndex--;
+                } else if (index == lastGetValue) {
+                    lastGetIndex--;
+                    lastGetValue = bitset.previousSetBit(lastGetValue-1);
+                }
+            }
+            if (lastGetIndex < -1) reset();
         }
     }
 


### PR DESCRIPTION
Hello, as I reported a few weeks ago regarding this issue #1597 , I have found the source of the problem and created a fix that should resolve it.

The problem seems to lie in the `lastGetIndex` and `lastGetValue` variables of the `BitSetReadOnlyUnbackedObservableList` class, which act as a cache for sequential queries to the `get(int index)` method. When modifications are made to the `BitSet` and, at the same time, observers are calling the get method, the cache becomes inconsistent in certain scenarios (such as the one reported in the issue). It is for this very reason that the tests performed with JUnit are unable to reproduce the problem. I have tried to reproduce it using existing and new tests to cover the code, but the test always passes regardless of whether the fix is applied or not. Below I detail each section.

### Bugs detected (before and after)
The first bug (reported in #1597 ), four or more elements selected sequentially and toggling the one at position -2
Before:
![idea64_bJs9rxiF8i](https://github.com/user-attachments/assets/0afb2786-0da0-4b1b-aaed-8b985935c086)
After:
![idea64_7W5Oo5tyC9](https://github.com/user-attachments/assets/2e0f1f5e-9bb0-44ef-8314-2c1025dc68f1)

The second bug, three non-contiguous elements selected (0, 2, and 4) and alternating position 1
Before:
![idea64_rUIuJEwW7y](https://github.com/user-attachments/assets/6ea756f9-c8de-4b2f-91f3-161d3142a455)
After:
![idea64_faWjuSoyEZ](https://github.com/user-attachments/assets/2e0118ae-9591-4522-9baa-e30667635a6f)

### Traces and useless tests
In this same fork, I have created a branch (`traces-CheckComboBox-inconsistent-selection`) with tests replicating these same bugs and traces in the CheckBitSetModelBase class, where you can see that the tests are unable to reproduce the problem:
First comment the fix:
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/4ab5ba1a-b582-4d49-8941-793c0cceead0" />
Then run the test (This corresponds to the second bug):
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/45ba1038-0155-4463-aee5-bf3150678e98" />
The test passes, although the traces show that it has attempted to change the status of row 3 (from true to true 🙃) instead of row 2.

Everything points to the fact that the bug cannot be reproduced because JavaFX makes calls to the get method through observers, which the test does not do. Here is a comparison between the output of the JUnit test and a manual test:

JUnit test:
```
[Test worker][get] index = 0, lastGetIndex = -1, lastGetValue = -1
[c.wasAdded()] item = Row 1, c.getAddedSubList() = [Test worker][get] index = 0, lastGetIndex = 0, lastGetValue = 0
[Row 1]
[updateBooleanProperty] item = Row 1, before = false, after = true
[check] index = 0, changeIndex = 0, changeIndex+1 = 1
[Test worker][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[c.wasAdded()] item = Row 3, c.getAddedSubList() = [Test worker][get] index = 1, lastGetIndex = 1, lastGetValue = 2
[Row 3]
[updateBooleanProperty] item = Row 3, before = false, after = true
[check] index = 2, changeIndex = 1, changeIndex+1 = 2
[Test worker][get] index = 2, lastGetIndex = 1, lastGetValue = 2
[c.wasAdded()] item = Row 5, c.getAddedSubList() = [Test worker][get] index = 2, lastGetIndex = 2, lastGetValue = 4
[Row 5]
[updateBooleanProperty] item = Row 5, before = false, after = true
[check] index = 4, changeIndex = 2, changeIndex+1 = 3
[Test worker][get] index = 1, lastGetIndex = 2, lastGetValue = 4
[c.wasAdded()] item = Row 3, c.getAddedSubList() = [Test worker][get] index = 1, lastGetIndex = 1, lastGetValue = 2
[Row 2]
[updateBooleanProperty] item = Row 3, before = true, after = true
[check] index = 1, changeIndex = 1, changeIndex+1 = 2
org.controlsfx.control.CheckBitSetModelBaseTest > testInconsistentSelectionCheckComboBoxRandom STARTED
org.controlsfx.control.CheckBitSetModelBaseTest > testInconsistentSelectionCheckComboBoxRandom PASSED
BUILD SUCCESSFUL in 765ms
```

Manual test:
```
[JavaFX Application Thread][get] index = 0, lastGetIndex = -1, lastGetValue = -1
[c.wasAdded()] item = Item 0, c.getAddedSubList() = [JavaFX Application Thread][get] index = 0, lastGetIndex = 0, lastGetValue = 0
[Item 0]
[updateBooleanProperty] item = Item 0, before = false, after = true
[JavaFX Application Thread][get] index = 0, lastGetIndex = 0, lastGetValue = 0
============================================
[JavaFX Application Thread][get] index = 0, lastGetIndex = 0, lastGetValue = 0
Change: { [Item 0] addition at 0,  }
[JavaFX Application Thread][get] index = 0, lastGetIndex = 0, lastGetValue = 0
Added sublist [Item 0]
Removed sublist []
[JavaFX Application Thread][get] index = 0, lastGetIndex = 0, lastGetValue = 0
List [Item 0]
Added true Permutated false Removed false Replaced false Updated false
============================================
[JavaFX Application Thread][get] index = 0, lastGetIndex = 0, lastGetValue = 0
[check] index = 0, changeIndex = 0, changeIndex+1 = 1
[JavaFX Application Thread][get] index = 0, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 0, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[c.wasAdded()] item = Item 2, c.getAddedSubList() = [JavaFX Application Thread][get] index = 1, lastGetIndex = 1, lastGetValue = 2
[Item 2]
[updateBooleanProperty] item = Item 2, before = false, after = true
[JavaFX Application Thread][get] index = 0, lastGetIndex = 1, lastGetValue = 2
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
============================================
[JavaFX Application Thread][get] index = 1, lastGetIndex = 1, lastGetValue = 2
Change: { [Item 2] addition at 1,  }
[JavaFX Application Thread][get] index = 1, lastGetIndex = 1, lastGetValue = 2
Added sublist [Item 2]
Removed sublist []
[JavaFX Application Thread][get] index = 0, lastGetIndex = 1, lastGetValue = 2
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
List [Item 0, Item 2]
Added true Permutated false Removed false Replaced false Updated false
============================================
[JavaFX Application Thread][get] index = 0, lastGetIndex = 1, lastGetValue = 2
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[check] index = 2, changeIndex = 1, changeIndex+1 = 2
[JavaFX Application Thread][get] index = 0, lastGetIndex = 1, lastGetValue = 2
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 0, lastGetIndex = 1, lastGetValue = 2
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 2
[c.wasAdded()] item = Item 4, c.getAddedSubList() = [JavaFX Application Thread][get] index = 2, lastGetIndex = 2, lastGetValue = 4
[Item 4]
[updateBooleanProperty] item = Item 4, before = false, after = true
[JavaFX Application Thread][get] index = 0, lastGetIndex = 2, lastGetValue = 4
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 2
============================================
[JavaFX Application Thread][get] index = 2, lastGetIndex = 2, lastGetValue = 4
Change: { [Item 4] addition at 2,  }
[JavaFX Application Thread][get] index = 2, lastGetIndex = 2, lastGetValue = 4
Added sublist [Item 4]
Removed sublist []
[JavaFX Application Thread][get] index = 0, lastGetIndex = 2, lastGetValue = 4
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 2
List [Item 0, Item 2, Item 4]
Added true Permutated false Removed false Replaced false Updated false
============================================
[JavaFX Application Thread][get] index = 0, lastGetIndex = 2, lastGetValue = 4
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 2
[check] index = 4, changeIndex = 2, changeIndex+1 = 3
[JavaFX Application Thread][get] index = 0, lastGetIndex = 2, lastGetValue = 4
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 2
[JavaFX Application Thread][get] index = 0, lastGetIndex = 2, lastGetValue = 4
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 2
[JavaFX Application Thread][get] index = 1, lastGetIndex = 2, lastGetValue = 4
[c.wasAdded()] item = Item 2, c.getAddedSubList() = [JavaFX Application Thread][get] index = 1, lastGetIndex = 1, lastGetValue = 2
[Item 1]
[updateBooleanProperty] item = Item 2, before = true, after = true
[JavaFX Application Thread][get] index = 0, lastGetIndex = 1, lastGetValue = 1
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 1
[JavaFX Application Thread][get] index = 3, lastGetIndex = 2, lastGetValue = 2
============================================
[JavaFX Application Thread][get] index = 1, lastGetIndex = 3, lastGetValue = 4
Change: { [Item 1] addition at 1,  }
[JavaFX Application Thread][get] index = 1, lastGetIndex = 1, lastGetValue = 1
Added sublist [Item 1]
Removed sublist []
[JavaFX Application Thread][get] index = 0, lastGetIndex = 1, lastGetValue = 1
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 1
[JavaFX Application Thread][get] index = 3, lastGetIndex = 2, lastGetValue = 2
List [Item 0, Item 1, Item 2, Item 4]
Added true Permutated false Removed false Replaced false Updated false
============================================
[JavaFX Application Thread][get] index = 0, lastGetIndex = 3, lastGetValue = 4
[JavaFX Application Thread][get] index = 1, lastGetIndex = 0, lastGetValue = 0
[JavaFX Application Thread][get] index = 2, lastGetIndex = 1, lastGetValue = 1
[JavaFX Application Thread][get] index = 3, lastGetIndex = 2, lastGetValue = 2
[check] index = 1, changeIndex = 1, changeIndex+1 = 2
```

All of this should be reproducible in the `traces-CheckComboBox-inconsistent-selection` branch of this same fork used to create the PR.