### PR TITLE
#1606: fixes TableRowExpanderColumn display/cache bug

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/ExpandableTableRowSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/ExpandableTableRowSkin.java
@@ -59,7 +59,7 @@ public class ExpandableTableRowSkin<S> extends TableRowSkin<S> {
         this.expander = expander;
         tableRow.itemProperty().addListener((observable, oldValue, newValue) -> {
             if (oldValue != null) {
-                Node expandedNode = this.expander.getExpandedNode(oldValue);
+                Node expandedNode = this.expander.removeExpandedNode(oldValue);
                 if (expandedNode != null) getChildren().remove(expandedNode);
             }
         });

--- a/controlsfx/src/main/java/org/controlsfx/control/table/TableRowExpanderColumn.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/table/TableRowExpanderColumn.java
@@ -107,12 +107,10 @@ public final class TableRowExpanderColumn<S> extends TableColumn<S, Boolean> {
             value = new SimpleBooleanProperty(item, "expanded", false) {
                 /**
                  * When the expanded state change we refresh the tableview.
-                 * If the expanded state changes to false we remove the cached expanded node.
                  */
                 @Override
                 protected void invalidated() {
                     getTableView().refresh();
-                    if (!getValue()) expandedNodeCache.remove(getBean());
                 }
             };
             expansionState.put(item, value);
@@ -141,13 +139,13 @@ public final class TableRowExpanderColumn<S> extends TableColumn<S, Boolean> {
     }
 
     /**
-     * Return the expanded node for the given item, if it exists.
+     * Remove and return the expanded node for the given item, if it exists.
      *
      * @param item The item corresponding to a table row
-     * @return The expanded node, if it exists.
+     * @return The removed expanded node, if it exists.
      */
-    public Node getExpandedNode(S item) {
-        return expandedNodeCache.get(item);
+    public Node removeExpandedNode(S item) {
+        return expandedNodeCache.remove(item);
     }
 
     /**


### PR DESCRIPTION
Fixes #1606 

Existing behaviour never worked as expected, nodes were removed from expandedNodeCache (expandedNodeCache.remove(getBean())) everytime a row was collapsed.

This meant that ExpandableTableRowSkin's tableRow.itemProperty() listener was was getting null from the cache, and unable to remove the children, to clean-up the row.

This problem went unnoticed until now because a table refresh was re-creating all cells anyway, so the un-removed nodes were getting discarded anyway. Now though, there are new optimisations in TableView which means these leftover nodes are visible as they're never never cleaned up from the rows.

The fix is to clean them up as I believe was originally intended.