### PR TITLE
Fix accumulated width in TableRow2Skin Fixes #1576

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2025, ControlsFX
+ * Copyright (c) 2013, 2026, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
@@ -690,7 +690,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
 
         final List<? extends TableColumnBase/*<T,?>*/> visibleLeafColumns = tableView.getVisibleLeafColumns();
         for (int i = 0, max = visibleLeafColumns.size(); i < max; i++) {
-            prefWidth += visibleLeafColumns.get(i).getWidth();
+            prefWidth += snapSizeX(visibleLeafColumns.get(i).getWidth());
         }
 
         return prefWidth;

--- a/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
@@ -34,6 +34,7 @@ import impl.org.controlsfx.tableview2.TableView2Skin;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
+import javafx.stage.Screen;
 import javafx.collections.ObservableList;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
@@ -459,6 +460,36 @@ public class TableView2Test extends FxRobot {
             assertNull("removed column should have no south header", removedHeader.get());
             assertSame("stable column header should be reused after remove", stableHeader.get(), stableHeaderAfter.get());
         }
+    }
+
+    /**
+     * Verifies that computePrefWidth sums snapped column widths, consistent with how
+     * layoutChildren accumulates x positions. Without the fix (issue #1576), the raw
+     * (unsnapped) sum was used, causing a mismatch with the snapped layout positions.
+     */
+    @Test
+    public void prefWidthShouldMatchSnappedColumnWidthSum_When_ColumnsHaveFractionalWidth() {
+        fillTableData();
+
+        final double fractionalWidth = 75.3;
+        interact(() -> tableView.getVisibleLeafColumns()
+                .forEach(col -> col.setPrefWidth(fractionalWidth)));
+
+        final AtomicReference<Double> actualPrefWidthHolder = new AtomicReference<>();
+        final AtomicReference<Double> expectedPrefWidthHolder = new AtomicReference<>();
+
+        interact(() -> {
+            TableView2Skin<?> skin = (TableView2Skin<?>) tableView.getSkin();
+            TableRow2<?> row = (TableRow2<?>) skin.getRow(0);
+            actualPrefWidthHolder.set(row.prefWidth(-1));
+
+            // Replicate snapSizeX: rounds up to the nearest physical pixel
+            double scale = Screen.getPrimary().getOutputScaleX();
+            double snappedColWidth = Math.ceil(fractionalWidth * scale) / scale;
+            expectedPrefWidthHolder.set(tableView.getVisibleLeafColumns().size() * snappedColWidth);
+        });
+
+        assertEquals(expectedPrefWidthHolder.get(), actualPrefWidthHolder.get(), 0.001);
     }
 
     private Duration measure(Runnable operation) {


### PR DESCRIPTION
## Fixes #1576 
### Root cause
In`layoutChildren`, each column's width is computed as `snapSizeX(column.getWidth())` (line 185), which rounds up to pixel boundaries. But `computePrefWidth` was summing the raw unsnapped widths. With ~100 columns, this accumulated rounding difference made `computePrefWidth` return a value smaller than the actual layout width, causing the scrollbar max to be set too low and leaving the rightmost columns unreachable.

### Fix
Apply `snapSizeX()` per column in `computePrefWidth`, so it matches the width calculation used in `layoutChildren`. 