### PR TITLE
TableView2: Validate index before accessing a list of table items, including test.

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/RowHeader.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/RowHeader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2020 ControlsFX
+ * Copyright (c) 2013, 2026, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -194,21 +194,30 @@ public class RowHeader<S> extends StackPane {
             skin.getSelectedRows().removeListener(tableSelectionListener);
             while (c.next()) {
                 c.getRemoved().forEach(i -> {
+                        if (!isValidIndex(tableView, i)) {
+                            return;
+                        }
                         if (tableView.getSelectionModel().isCellSelectionEnabled()) {
                             tableView.getVisibleLeafColumns().forEach(col -> tableView.getSelectionModel().clearSelection(i, col));
                         } else {
                             tableView.getSelectionModel().clearSelection(i);
                         }
                     });
-                c.getAddedSubList().forEach(i -> tableView.getSelectionModel().select(i));
+                c.getAddedSubList().stream()
+                        .filter(i -> isValidIndex(tableView, i))
+                        .forEach(i -> tableView.getSelectionModel().select(i));
             }
             skin.getSelectedRows().addListener(tableSelectionListener);
         };
         tableSelectionListener = (ListChangeListener.Change<? extends Integer> c) -> {
             innerTableView.getSelectionModel().getSelectedIndices().removeListener(rowHeaderSelectionListener);
             while (c.next()) {
-                c.getRemoved().forEach(i -> innerTableView.getSelectionModel().clearSelection(i));
-                c.getAddedSubList().forEach(i -> innerTableView.getSelectionModel().select(i));
+                c.getRemoved().stream()
+                        .filter(i -> isValidIndex(innerTableView, i))
+                        .forEach(i -> innerTableView.getSelectionModel().clearSelection(i));
+                c.getAddedSubList().stream()
+                        .filter(i -> isValidIndex(innerTableView, i))
+                        .forEach(i -> innerTableView.getSelectionModel().select(i));
             }
             if (! sorting) {
                 innerTableView.getSelectionModel().getSelectedIndices().addListener(rowHeaderSelectionListener);
@@ -242,7 +251,9 @@ public class RowHeader<S> extends StackPane {
                 }
                 innerTableView.getSelectionModel().clearSelection();
                 if (innerTableView.getItems() != null) {
-                    skin.getSelectedRows().forEach(i -> innerTableView.getSelectionModel().select(i));
+                    skin.getSelectedRows().stream()
+                            .filter(i -> isValidIndex(innerTableView, i))
+                            .forEach(i -> innerTableView.getSelectionModel().select(i));
                 }
                 innerTableView.getSelectionModel().getSelectedIndices().addListener(rowHeaderSelectionListener);
             }
@@ -255,6 +266,15 @@ public class RowHeader<S> extends StackPane {
         tableView.focusedProperty().addListener(focusListener);
         innerTableView.focusedProperty().addListener(focusListener);
 
+    }
+
+    /**
+     * Check that the {@code index} is within range of the {@code table} items list,
+     * as a safeguard to prevent {@link IndexOutOfBoundsException}.
+     */
+    private boolean isValidIndex(TableView2<S> table, Integer index) {
+        return index != null && table != null && table.getItems() != null &&
+                0 <= index && index < table.getItems().size();
     }
 
     public double getRowHeaderWidth() {

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableView2Skin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableView2Skin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2025, ControlsFX
+ * Copyright (c) 2013, 2026, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -934,10 +934,13 @@ public class TableView2Skin<S> extends TableViewSkin<S> {
     }
     
     private void updateHeaders() {
+        final int itemCount = tableView.getItems() == null ? 0 : tableView.getItems().size();
+        final int columnCount = tableView.getVisibleLeafColumns().size();
         final ObservableList<TablePosition> selectedCells = tableView.getSelectionModel().getSelectedCells();
         final List<Integer> columns = selectedCells.stream()
                 .map(TablePosition::getColumn)
-                .filter(column -> (column > -1 && tableView.getSelectionModel().isCellSelectionEnabled()))
+                .filter(column -> 0 <= column && column < columnCount &&
+                        tableView.getSelectionModel().isCellSelectionEnabled())
                 .collect(Collectors.toList());
         if (! oldSelectedColumns.equals(columns)) {
             oldSelectedColumns.clear();
@@ -946,6 +949,7 @@ public class TableView2Skin<S> extends TableViewSkin<S> {
         }
         final List<Integer> rows = selectedCells.stream()
                 .map(TablePosition::getRow)
+                .filter(row -> 0 <= row && row < itemCount)
                 .collect(Collectors.toList());
         if (! oldSelectedRows.equals(rows)) {
             oldSelectedRows.clear();

--- a/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/tableview2/TableView2Test.java
@@ -40,6 +40,7 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollBar;
+import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
@@ -364,6 +365,40 @@ public class TableView2Test extends FxRobot {
         interact(() -> recreatedHeader.set(getSouthHeaderRow().getSouthColumnHeaderFor(toggledColumn)));
         assertNotNull(recreatedHeader.get());
         assertNotSame(originalHeader.get(), recreatedHeader.get());
+    }
+
+    /**
+     * Asserts that clearing the items doesn't throw an IndexOutOfBoundsException when
+     * several cells from different rows are selected and the row header is visible.
+     */
+    @Test
+    public void shouldNotThrow_When_ItemsAreClearedWithMultipleSelectedRows() {
+        fillTableData();
+
+        interact(() -> {
+            tableView.setRowHeaderVisible(true);
+            tableView.getSelectionModel().setCellSelectionEnabled(true);
+            tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+        });
+
+        interact(() -> {
+            TableColumn<RowItem, ?> column = tableView.getVisibleLeafColumn(0);
+            tableView.getSelectionModel().select(3, column);
+            tableView.getSelectionModel().select(14, column);
+        });
+
+        final AtomicReference<Throwable> exception = new AtomicReference<>();
+        interact(() -> {
+            try {
+                tableView.getItems().clear();
+            } catch (Throwable t) {
+                exception.set(t);
+            }
+        });
+
+        assertNull(exception.get());
+        assertThat(tableView.getItems().isEmpty(), is(true));
+        assertThat(tableView.getSelectionModel().getSelectedCells().isEmpty(), is(true));
     }
 
     /**


### PR DESCRIPTION
Fixes #1503 

From the stacktrace in the issue, the problem is that, when the RowHeader is used, the items of the internal TableView are cleared before the selection is cleared, and in the process, the selection invalid indices are still used to try to access the inner tableView selection items, which are empty, throwing the IOOBE.

The fix is just a safeguard that validates any index that is used to access a tableView items list. 

A test has also been included, that fails before this PR, and passes after it.