### PR TITLE
Detach rows in the table-filter memory sample

### DIFF
--- a/controlsfx-samples/src/main/java/org/controlsfx/samples/tablefilter/TableFilterMemoryTest.java
+++ b/controlsfx-samples/src/main/java/org/controlsfx/samples/tablefilter/TableFilterMemoryTest.java
@@ -55,7 +55,7 @@ public class TableFilterMemoryTest extends Application {
         // Add new data
         ObservableList<Row> ans = FXCollections.observableArrayList();
         for (int i = 0; i < 1024; i++) {
-            ans.add(new Row());
+            ans.add(new Row(rangeStart));
         }
         table.setItems(ans);
 
@@ -73,10 +73,10 @@ public class TableFilterMemoryTest extends Application {
         primaryStage.show();
     }
 
-    class Row {
+    static class Row {
         public final String[] data;
 
-        public Row() {
+        public Row(int rangeStart) {
             data = new String[ColCount];
             for (int i = 0; i < ColCount; i++) {
                 data[i] = String.format("%d", rangeStart + rng.nextInt(10));


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/54491401.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Make sample rows static and pass their range explicitly so each row does not retain the enclosing memory-test application.

<!-- Include the Testing section only when a relevant test exists and was run. Otherwise remove this comment and the entire section below. -->
