### PR TITLE
Replace deprecated snap methods with axis aware snap methods

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/CustomTextFieldSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/CustomTextFieldSkin.java
@@ -100,11 +100,11 @@ public abstract class CustomTextFieldSkin extends TextFieldSkin {
     @Override protected void layoutChildren(double x, double y, double w, double h) {
         final double fullHeight = h + snappedTopInset() + snappedBottomInset();
         
-        final double leftWidth = leftPane == null ? 0.0 : snapSize(leftPane.prefWidth(fullHeight));
-        final double rightWidth = rightPane == null ? 0.0 : snapSize(rightPane.prefWidth(fullHeight));
+        final double leftWidth = leftPane == null ? 0.0 : snapSizeX(leftPane.prefWidth(fullHeight));
+        final double rightWidth = rightPane == null ? 0.0 : snapSizeX(rightPane.prefWidth(fullHeight));
         
-        final double textFieldStartX = snapPosition(x) + snapSize(leftWidth);
-        final double textFieldWidth = w - snapSize(leftWidth) - snapSize(rightWidth);
+        final double textFieldStartX = snapPositionX(x) + snapSizeX(leftWidth);
+        final double textFieldWidth = w - snapSizeX(leftWidth) - snapSizeX(rightWidth);
         
         super.layoutChildren(textFieldStartX, 0, textFieldWidth, fullHeight);
 
@@ -126,15 +126,15 @@ public abstract class CustomTextFieldSkin extends TextFieldSkin {
          * when we have a left Node and the click point is badly returned
          * because we weren't considering the shift induced by the leftPane.
          */
-        final double leftWidth = leftPane == null ? 0.0 : snapSize(leftPane.prefWidth(getSkinnable().getHeight()));
+        final double leftWidth = leftPane == null ? 0.0 : snapSizeX(leftPane.prefWidth(getSkinnable().getHeight()));
         return super.getIndex(x - leftWidth, y);
     }
     
     @Override
     protected double computePrefWidth(double h, double topInset, double rightInset, double bottomInset, double leftInset) {
         final double pw = super.computePrefWidth(h, topInset, rightInset, bottomInset, leftInset);
-        final double leftWidth = leftPane == null ? 0.0 : snapSize(leftPane.prefWidth(h));
-        final double rightWidth = rightPane == null ? 0.0 : snapSize(rightPane.prefWidth(h));
+        final double leftWidth = leftPane == null ? 0.0 : snapSizeX(leftPane.prefWidth(h));
+        final double rightWidth = rightPane == null ? 0.0 : snapSizeX(rightPane.prefWidth(h));
     
         return pw + leftWidth + rightWidth;
     }
@@ -142,8 +142,8 @@ public abstract class CustomTextFieldSkin extends TextFieldSkin {
     @Override
     protected double computePrefHeight(double w, double topInset, double rightInset, double bottomInset, double leftInset) {
         final double ph = super.computePrefHeight(w, topInset, rightInset, bottomInset, leftInset);
-        final double leftHeight = leftPane == null ? 0.0 : snapSize(leftPane.prefHeight(-1));
-        final double rightHeight = rightPane == null ? 0.0 : snapSize(rightPane.prefHeight(-1));
+        final double leftHeight = leftPane == null ? 0.0 : snapSizeY(leftPane.prefHeight(-1));
+        final double rightHeight = rightPane == null ? 0.0 : snapSizeY(rightPane.prefHeight(-1));
         
         return Math.max(ph, Math.max(leftHeight, rightHeight));
     }
@@ -151,8 +151,8 @@ public abstract class CustomTextFieldSkin extends TextFieldSkin {
     @Override
     protected double computeMinWidth(double h, double topInset, double rightInset, double bottomInset, double leftInset) {
         final double mw = super.computeMinWidth(h, topInset, rightInset, bottomInset, leftInset);
-        final double leftWidth = leftPane == null ? 0.0 : snapSize(leftPane.minWidth(h));
-        final double rightWidth = rightPane == null ? 0.0 : snapSize(rightPane.minWidth(h));
+        final double leftWidth = leftPane == null ? 0.0 : snapSizeX(leftPane.minWidth(h));
+        final double rightWidth = rightPane == null ? 0.0 : snapSizeX(rightPane.minWidth(h));
 
         return mw + leftWidth + rightWidth;
     }
@@ -160,8 +160,8 @@ public abstract class CustomTextFieldSkin extends TextFieldSkin {
     @Override
     protected double computeMinHeight(double w, double topInset, double rightInset, double bottomInset, double leftInset) {
         final double mh = super.computeMinHeight(w, topInset, rightInset, bottomInset, leftInset);
-        final double leftHeight = leftPane == null ? 0.0 : snapSize(leftPane.minHeight(-1));
-        final double rightHeight = rightPane == null ? 0.0 : snapSize(rightPane.minHeight(-1));
+        final double leftHeight = leftPane == null ? 0.0 : snapSizeY(leftPane.minHeight(-1));
+        final double rightHeight = rightPane == null ? 0.0 : snapSizeY(rightPane.minHeight(-1));
 
         return Math.max(mh, Math.max(leftHeight, rightHeight));
     }

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/InfoOverlaySkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/InfoOverlaySkin.java
@@ -150,14 +150,14 @@ public class InfoOverlaySkin extends SkinBase<InfoOverlay> {
 
         // All remaining width goes to the info label
         final Insets infoPanelPadding = infoPanel.getPadding();
-        final double infoLabelWidth = snapSize(contentWidth - toggleButtonPrefWidth - 
+        final double infoLabelWidth = snapSizeX(contentWidth - toggleButtonPrefWidth -
                 infoPanelPadding.getLeft() - infoPanelPadding.getRight());
 
         // we then can work out the necessary height for the info panel, based on
         // whether it is expanded or not, and given the current state of the animation.
-        final double prefInfoPanelHeight = (snapSize(infoLabel.prefHeight(infoLabelWidth)) +
-                snapSpace(infoPanel.getPadding().getTop()) +
-                snapSpace(infoPanel.getPadding().getBottom())) *
+        final double prefInfoPanelHeight = (snapSizeY(infoLabel.prefHeight(infoLabelWidth)) +
+                snapSpaceY(infoPanel.getPadding().getTop()) +
+                snapSpaceY(infoPanel.getPadding().getBottom())) *
                 transition.get();
 
         infoLabel.setMaxWidth(infoLabelWidth);
@@ -168,7 +168,7 @@ public class InfoOverlaySkin extends SkinBase<InfoOverlay> {
                                 contentWidth, contentHeight, -1, HPos.CENTER, VPos.TOP);
         
         // position the infoPanel (the HBox consisting of the Label and ToggleButton)
-        layoutInArea(infoPanel, contentX, snapPosition(contentPrefHeight - prefInfoPanelHeight),
+        layoutInArea(infoPanel, contentX, snapPositionY(contentPrefHeight - prefInfoPanelHeight),
                                 contentWidth, prefInfoPanelHeight, 0, HPos.CENTER, VPos.BOTTOM);
     }
 

--- a/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/GridRowSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/GridRowSkin.java
@@ -196,7 +196,7 @@ public class GridRowSkin extends CellSkinBase<TableRow<ObservableList<Spreadshee
             if(!skin.getSkinnable().getColumns().get(indexColumn).isVisible()){
                 continue;
             }
-            width = snapSize(columns.get(indexColumn).getWidth()) - snapSize(horizontalPadding);
+            width = snapSizeX(columns.get(indexColumn).getWidth()) - snapSizeX(horizontalPadding);
             //When setting a new grid with less columns, we may have this situation.
             if (row.size() <= indexColumn) {
                 break;
@@ -308,7 +308,7 @@ public class GridRowSkin extends CellSkinBase<TableRow<ObservableList<Spreadshee
                      */
                     final int max = skin.getSkinnable().getVisibleLeafColumns().size() - viewColumn;
                     for (int i = 1; i < columnSpan && i < max; i++) {
-                        double tempWidth = snapSize(skin.getSkinnable().getVisibleLeafColumn(viewColumn + i).getWidth());
+                        double tempWidth = snapSizeX(skin.getSkinnable().getVisibleLeafColumn(viewColumn + i).getWidth());
                         width += tempWidth;
                         if (increaseFixedWidth) {
                             fixedColumnWidth += tempWidth;
@@ -347,7 +347,7 @@ public class GridRowSkin extends CellSkinBase<TableRow<ObservableList<Spreadshee
                 }
 
                 height = customHeight;
-                height = snapSize(height) - snapSize(verticalPadding);
+                height = snapSizeY(height) - snapSizeY(verticalPadding);
                 /**
                  * We need to span multiple rows, so we sum up the height of all
                  * the rows. The height of the current row is ignored and the
@@ -365,7 +365,7 @@ public class GridRowSkin extends CellSkinBase<TableRow<ObservableList<Spreadshee
                     int newIndex = index - reverseRowSpan;
                     final int maxRow = newIndex + reverseRowSpan + rowSpan;
                     for (int i = newIndex + 1; i < maxRow; ++i) {
-                        height += snapSize(skin.getRowHeight(i));
+                        height += snapSizeY(skin.getRowHeight(i));
                     }
                 }
 

--- a/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/GridViewSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/GridViewSkin.java
@@ -487,7 +487,7 @@ public class GridViewSkin extends TableViewSkinBase<ObservableList<SpreadsheetCe
                  */
                 final int max = getSkinnable().getVisibleLeafColumns().size() - viewColumn;
                 for (int i = 1, colSpan = spc.getColumnSpan(); i < colSpan && i < max; i++) {
-                    double tempWidth = snapSize(getSkinnable().getVisibleLeafColumn(viewColumn + i).getWidth());
+                    double tempWidth = snapSizeX(getSkinnable().getVisibleLeafColumn(viewColumn + i).getWidth());
                     width += tempWidth;
                 }
             }
@@ -700,7 +700,7 @@ public class GridViewSkin extends TableViewSkinBase<ObservableList<SpreadsheetCe
          * column with his mouse, we must force the column to resize because
          * setting the prefWidth again will not trigger the listeners.
          */
-        widthMax = snapSize(widthMax);
+        widthMax = snapSizeX(widthMax);
         if (col.getPrefWidth() == widthMax && col.getWidth() != widthMax) {
             //FIXME
 //            col.impl_setWidth(widthMax);

--- a/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/HorizontalHeaderColumn.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/HorizontalHeaderColumn.java
@@ -108,7 +108,7 @@ public class HorizontalHeaderColumn extends NestedTableColumnHeader {
         max = max > spreadsheetView.getColumns().size() ? spreadsheetView.getColumns().size() : max;
         for (int j = 0; j < max; j++) {
             final TableColumnHeader n = getColumnHeaders().get(j);
-            final double prefWidth = snapSize(n.prefWidth(-1));
+            final double prefWidth = snapSizeX(n.prefWidth(-1));
             n.setPrefHeight(24.0);
             //If the column is fixed
             if (spreadsheetView.getColumns().get(spreadsheetView.getModelColumn(j)).isFixed()) {

--- a/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/RectangleSelection.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/RectangleSelection.java
@@ -231,7 +231,7 @@ public class RectangleSelection extends Rectangle {
         //We first compute the total space between the left edge and our first column
         for (int i = 0; i < minColumn; ++i) {
             //Here we use Ceil because we want to "snapSize" otherwise we may end up with a weird shift.
-            x += snapSize(visibleColumns.get(i).getWidth());
+            x += snapSizeX(visibleColumns.get(i).getWidth());
         }
 
         /**
@@ -244,7 +244,7 @@ public class RectangleSelection extends Rectangle {
         //Then we compute the width by adding the space between the min and max column
         double width = 0;
         for (int i = minColumn; i <= maxColumn /*+ (columnSpan - 1)*/; ++i) {
-            width += snapSize(visibleColumns.get(i).getWidth());
+            width += snapSizeX(visibleColumns.get(i).getWidth());
         }
 
         //FIXED COLUMNS
@@ -280,10 +280,10 @@ public class RectangleSelection extends Rectangle {
                 for (SpreadsheetColumn column : skin.spreadsheetView.getFixedColumns()) {
                     int indexColumn = skin.spreadsheetView.getViewColumn(columns.indexOf(column));
                     if (indexColumn < minColumn && indexColumn != minColumn) {
-                        x += snapSize(column.getWidth());
+                        x += snapSizeX(column.getWidth());
                     }
                     if (indexColumn >= minColumn && indexColumn <= maxColumn) {
-                        width += snapSize(column.getWidth());
+                        width += snapSizeX(column.getWidth());
                     }
                 }
                 /**
@@ -296,7 +296,7 @@ public class RectangleSelection extends Rectangle {
                 for (SpreadsheetColumn column : skin.spreadsheetView.getFixedColumns()) {
                     int indexColumn = skin.spreadsheetView.getViewColumn(columns.indexOf(column));
                     if (indexColumn < minColumn && indexColumn != minColumn) {
-                        tempX += snapSize(column.getWidth());
+                        tempX += snapSizeX(column.getWidth());
                     }
                 }
                 width -= tempX - x;
@@ -313,7 +313,7 @@ public class RectangleSelection extends Rectangle {
      * @param value the size value to be snapped
      * @return value ceiled to nearest pixel
      */
-    private double snapSize(double value) {
+    private double snapSizeX(double value) {
         return Math.ceil(value);
     }
 

--- a/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/VerticalHeader.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/spreadsheet/VerticalHeader.java
@@ -159,7 +159,7 @@ public class VerticalHeader extends StackPane {
         handle.getView().hiddenColumnsProperty().addListener(layout);
 
         // Clip property to stay within bounds
-        clip = new Rectangle(getVerticalHeaderWidth(), snapSize(skin.getSkinnable().getHeight()));
+        clip = new Rectangle(getVerticalHeaderWidth(), snapSizeY(skin.getSkinnable().getHeight()));
         clip.relocate(snappedTopInset(), snappedLeftInset());
         clip.setSmooth(false);
         clip.heightProperty().bind(skin.getSkinnable().heightProperty());

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/NestedTableColumnHeader2.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/NestedTableColumnHeader2.java
@@ -129,8 +129,8 @@ public class NestedTableColumnHeader2 extends NestedTableColumnHeader {
                 continue;
             }
             
-            final double prefWidth = snapSize(n.prefWidth(-1));
-            n.resize(prefWidth, snapSize(h - labelHeight));
+            final double prefWidth = snapSizeX(n.prefWidth(-1));
+            n.resize(prefWidth, snapSizeY(h - labelHeight));
             //If the column is fixed
             TableColumn<?, ?> column = (TableColumn<?, ?>) n.getTableColumn();
             boolean isLeafColumn = column.getParentColumn() != null;

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/RowHeader.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/RowHeader.java
@@ -133,7 +133,7 @@ public class RowHeader<S> extends StackPane {
 
         // Clip property to stay within bounds
         clip = new Rectangle(getRowHeaderWidth(),
-                snapSize(tableView.getHeight() - tableView.snappedTopInset() - tableView.snappedBottomInset()));
+                snapSizeY(tableView.getHeight() - tableView.snappedTopInset() - tableView.snappedBottomInset()));
         clip.relocate(snappedTopInset(), snappedLeftInset());
         clip.setSmooth(false);
         clip.heightProperty().bind(Bindings.createDoubleBinding(() ->
@@ -312,7 +312,7 @@ public class RowHeader<S> extends StackPane {
             }
             final ScrollBar hBar = skin.getHBar();
             double hBarHeight = hBar.isVisible() && tableView.getItems() != null && ! tableView.getItems().isEmpty() ?
-                    snapSize(hBar.getHeight()) : 0;
+                    snapSizeY(hBar.getHeight()) : 0;
             innerTableView.resizeRelocate(x, 0, innerRowHeaderWidth.get(), tableView.getHeight() - hBarHeight -
                     tableView.snappedTopInset() - tableView.snappedBottomInset());
             if (! innerTableView.getColumns().isEmpty()) {

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/SouthTableHeaderRow.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/SouthTableHeaderRow.java
@@ -124,7 +124,7 @@ public class SouthTableHeaderRow extends Region {
             SouthTableColumnHeader n = getSouthColumnHeaders().get(i);
             if (! n.isVisible()) continue;
 
-            double prefWidth = snapSize(n.prefWidth(-1));
+            double prefWidth = snapSizeX(n.prefWidth(-1));
             TableColumn<?, ?> column = (TableColumn<?, ?>) n.getTableColumn();
             while (column.getParentColumn() != null) {
                 column = (TableColumn<?, ?>) column.getParentColumn();
@@ -139,7 +139,7 @@ public class SouthTableHeaderRow extends Region {
                 }
             }
             n.relocate(x + tableCellX, snappedTopInset());
-            n.resize(prefWidth, snapSize(h));
+            n.resize(prefWidth, snapSizeY(h));
             x += prefWidth;
         }
     }

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableHeaderRow2.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableHeaderRow2.java
@@ -176,14 +176,14 @@ public class TableHeaderRow2 extends TableHeaderRow {
     /** {@inheritDoc} */
     @Override protected void layoutChildren() {
         double x = scrollX;
-        double headerWidth = snapSize(header.prefWidth(-1));
+        double headerWidth = snapSizeX(header.prefWidth(-1));
         
         double southTableHeaderRowHeight = southHeaderRow.prefHeight(headerWidth);
         
         southHeaderRow.resizeRelocate(x, getHeight() - snappedBottomInset() - southTableHeaderRowHeight, headerWidth, southTableHeaderRowHeight);
             
         double prefHeight = getHeight() - snappedTopInset() - snappedBottomInset();
-        double cornerWidth = snapSize(skin.getFlow().getVerticalBar().prefWidth(-1));
+        double cornerWidth = snapSizeX(skin.getFlow().getVerticalBar().prefWidth(-1));
 
         // position the main nested header
         header.resizeRelocate(x, snappedTopInset(), headerWidth, prefHeight - southTableHeaderRowHeight);

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableRow2Skin.java
@@ -310,7 +310,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
                 int viewColumn = skin.getViewColumn(indexColumn);
                 final int max = tableView.getVisibleLeafColumns().size() - viewColumn;
                 for (int i = 1, colSpan = columnSpan; i < colSpan && i < max; i++) {
-                    double tempWidth = snapSize(tableView.getVisibleLeafColumn(viewColumn + i).getWidth());
+                    double tempWidth = snapSizeX(tableView.getVisibleLeafColumn(viewColumn + i).getWidth());
                     width += tempWidth;
                     if (increaseFixedWidth) {
                         fixedColumnWidth += tempWidth;
@@ -360,7 +360,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
             }
 
             height = customHeight;
-            height = snapSize(height) - snapSize(verticalPadding);
+            height = snapSizeY(height) - snapSizeY(verticalPadding);
             /**
              * We need to span multiple rows, so we sum up the height of all
              * the rows. The height of the current row is ignored and the
@@ -371,7 +371,7 @@ public class TableRow2Skin<S> extends CellSkinBase<TableRow<S>> {
                 height = 0;
                 final int maxRow = index + rowSpan;
                 for (int i = index; i < maxRow; ++i) {
-                    height += snapSize(skin.getRowHeight(i));
+                    height += snapSizeY(skin.getRowHeight(i));
                 }
             }
 

--- a/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableView2Skin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/tableview2/TableView2Skin.java
@@ -487,7 +487,7 @@ public class TableView2Skin<S> extends TableViewSkin<S> {
 ////            widthMax = Math.max(widthMax, col.getWidth());
 ////        }
 ////        
-////        widthMax = snapSize(widthMax);
+////        widthMax = snapSizeX(widthMax);
 ////        
 ////        col.impl_setWidth(widthMax);
 ////    }


### PR DESCRIPTION
In https://github.com/openjdk/jfx/pull/2270, I marked the already deprecated `snapXXX` methods as deprecated `forRemoval = true`.

This PR replaces all deprecated snap methods with their correct axis aware variant. No other changes or problems are expected.

Since those methods will be removed in a future release, we should replace them now than later.