### PR TITLE
Fix the check model of CheckListView / CheckComboBox losing track of its checks

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/collections/ChangeHelper.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/collections/ChangeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ControlsFX
+ * Copyright (c) 2018, 2026, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,12 +31,17 @@ import java.util.List;
 
 class ChangeHelper {
     
-    static String addRemoveChangeToString(int from, int to, List<?> list, List<?> removed) {
+    /**
+     * The text of the given add/remove change, built from the elements it added and the ones it
+     * removed. The added elements are taken as given rather than read back from the list, which a
+     * change reported from a snapshot is free to no longer stand for.
+     */
+    static String addRemoveChangeToString(int from, int to, List<?> added, List<?> removed) {
         
         StringBuilder b = new StringBuilder();
 
         if (removed.isEmpty()) {
-            b.append(list.subList(from, to));
+            b.append(added);
             b.append(" addition at ").append(from);
         } else {
             b.append(removed);
@@ -44,7 +49,7 @@ class ChangeHelper {
                 b.append(" removal at ").append(from);
             } else {
                 b.append(" replaced by ");
-                b.append(list.subList(from, to));
+                b.append(added);
                 b.append(" at ").append(from);
             }
         }

--- a/controlsfx/src/main/java/impl/org/controlsfx/collections/MappingChange.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/collections/MappingChange.java
@@ -138,7 +138,7 @@ public final class MappingChange<E, F> extends Change<F> {
             } else if (wasUpdated()) {
                 b.append(ChangeHelper.updateChangeToString(getFrom(), getTo()));
             } else {
-                b.append(ChangeHelper.addRemoveChangeToString(getFrom(), getTo(), getList(), getRemoved()));
+                b.append(ChangeHelper.addRemoveChangeToString(getFrom(), getTo(), getAddedSubList(), getRemoved()));
             }
             if (pos != size) {
                 b.append(", ");

--- a/controlsfx/src/main/java/impl/org/controlsfx/collections/NonIterableChange.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/collections/NonIterableChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ControlsFX
+ * Copyright (c) 2018, 2026, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -92,7 +92,7 @@ public abstract class NonIterableChange<E> extends Change<E> {
         } else if (wasUpdated()) {
             string = ChangeHelper.updateChangeToString(from, to);
         } else {
-            string = ChangeHelper.addRemoveChangeToString(from, to, getList(), getRemoved());
+            string = ChangeHelper.addRemoveChangeToString(from, to, getAddedSubList(), getRemoved());
         }
         invalid = tempInvalid;
         return "{ " + string + " }";

--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/CheckComboBoxSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/CheckComboBoxSkin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2022, ControlsFX
+ * Copyright (c) 2013, 2026, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,6 @@
  */
 package impl.org.controlsfx.skin;
 
-import impl.org.controlsfx.collections.ReadOnlyUnbackedObservableList;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -44,6 +43,9 @@ import javafx.scene.input.KeyCombination;
 import org.controlsfx.control.CheckComboBox;
 
 import org.controlsfx.control.IndexedCheckModel;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.controlsfx.control.CheckComboBox.COMBO_BOX_ROWS_TO_MEASURE_WIDTH_KEY;
 
@@ -70,8 +72,8 @@ public class CheckComboBoxSkin<T> extends SkinBase<CheckComboBox<T>> {
     // data
     private final CheckComboBox<T> control;
     private final ObservableList<T> items;
-    private final ReadOnlyUnbackedObservableList<Integer> selectedIndices;
-    private final ReadOnlyUnbackedObservableList<T> selectedItems;
+    // the listener through which this skin follows the checks of the model the control has
+    private final ListChangeListener<Integer> checkedIndicesListener;
     
     
     /**************************************************************************
@@ -86,9 +88,6 @@ public class CheckComboBoxSkin<T> extends SkinBase<CheckComboBox<T>> {
         
         this.control = control;
         this.items = control.getItems();
-        
-        selectedIndices = (ReadOnlyUnbackedObservableList<Integer>) control.getCheckModel().getCheckedIndices();
-        selectedItems = (ReadOnlyUnbackedObservableList<T>) control.getCheckModel().getCheckedItems();
         
         comboBox = new ComboBox<T>(items) {
             @Override
@@ -135,7 +134,15 @@ public class CheckComboBoxSkin<T> extends SkinBase<CheckComboBox<T>> {
 
         // The zero is a dummy value - it just has to be legally within the bounds of the
         // item count for the CheckComboBox items list.
-        selectedIndices.addListener((ListChangeListener<Integer>) c -> buttonCell.updateIndex(0));
+        checkedIndicesListener = c -> buttonCell.updateIndex(0);
+
+        // the button renders the checks of the model the control has, which an application is
+        // free to replace through CheckComboBox.setCheckModel(IndexedCheckModel)
+        followCheckModel(null, control.getCheckModel());
+        control.checkModelProperty().addListener((o, oldModel, newModel) -> {
+            followCheckModel(oldModel, newModel);
+            buttonCell.updateIndex(0);
+        });
         
         getChildren().add(comboBox);
     }
@@ -204,7 +211,7 @@ public class CheckComboBoxSkin<T> extends SkinBase<CheckComboBox<T>> {
             String vResult = control.getTitle();
             if (control.isShowCheckedCount()) {
                 //...adding also the count of how many are selected, if so configured
-                vResult = String.format("%s (%d/%d)", vResult, selectedItems.size(), items.size());
+                vResult = String.format("%s (%d/%d)", vResult, getCheckedItems().size(), items.size());
             }
             return vResult;
         } else {            
@@ -214,10 +221,27 @@ public class CheckComboBoxSkin<T> extends SkinBase<CheckComboBox<T>> {
         
     }
     
+    /** Follows the checked indices of the model the control is given, and only of that one. */
+    private void followCheckModel(IndexedCheckModel<T> droppedModel, IndexedCheckModel<T> newModel) {
+        if (droppedModel != null) {
+            droppedModel.getCheckedIndices().removeListener(checkedIndicesListener);
+        }
+        if (newModel != null) {
+            newModel.getCheckedIndices().addListener(checkedIndicesListener);
+        }
+    }
+
+    /** The items checked in the model the control has - what the button is to render. */
+    private List<T> getCheckedItems() {
+        final IndexedCheckModel<T> checkModel = control.getCheckModel();
+        return checkModel == null ? Collections.emptyList() : checkModel.getCheckedItems();
+    }
+
     private String buildString() {
         final StringBuilder sb = new StringBuilder();
-        for (int i = 0, max = selectedItems.size(); i < max; i++) {
-            T item = selectedItems.get(i);
+        final List<T> checkedItems = getCheckedItems();
+        for (int i = 0, max = checkedItems.size(); i < max; i++) {
+            T item = checkedItems.get(i);
             if (control.getConverter() == null) {
                 sb.append(item);
             } else {

--- a/controlsfx/src/main/java/org/controlsfx/control/CheckBitSetModelBase.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckBitSetModelBase.java
@@ -253,8 +253,10 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
             setItemChecked(item, true);
         }
 
-        updateFollowedProperties();
+        // reported before the properties are written: a listener of a property this model is
+        // clearing is free to reach back into it, and has to be answered the checks it now holds
         fireChangesAfterItemsChanged();
+        updateFollowedProperties();
     }
 
     /**
@@ -295,13 +297,18 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
         }
     }
 
-    /** Sets the check state of every row holding the given item; returns whether any row changed. */
+    /**
+     * Sets the check state of every row holding the given item; returns whether any row changed.
+     * The rows are read from the index this model holds of the item list, which a model detached
+     * from that list stops following: a row which no longer holds the item is left alone.
+     */
     private boolean setItemChecked(T item, boolean checked) {
         boolean changed = false;
         List<Integer> rows = itemRows.get(item);
         if (rows != null) {
             for (int row : rows) {
-                if (checkedIndices.get(row) != checked) {
+                if (isValidIndex(row) && Objects.equals(getItem(row), item)
+                        && checkedIndices.get(row) != checked) {
                     checkedIndices.set(row, checked);
                     changed = true;
                 }
@@ -317,18 +324,33 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
     }
 
     private void updateFollowedProperties() {
-        final List<BooleanProperty> droppedProperties = new ArrayList<>();
+        final Map<T, List<Integer>> rows = itemRows;
         for (Iterator<Map.Entry<T, FollowedProperty>> it = followedProperties.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<T, FollowedProperty> followed = it.next();
-            if (!itemRows.containsKey(followed.getKey())) {
+            if (!rows.containsKey(followed.getKey())) {
                 followed.getValue().detach();
-                droppedProperties.add(followed.getValue().property);
                 it.remove();
             }
         }
-        itemBooleanMap.keySet().retainAll(itemRows.keySet());
 
-        for (T item : itemRows.keySet()) {
+        // the property of an item which is not in the list leaves the map whichever model put it
+        // there, the map being shared with the control and with the models built on it afterwards
+        final List<BooleanProperty> droppedProperties = new ArrayList<>();
+        for (Iterator<Map.Entry<T, BooleanProperty>> it = itemBooleanMap.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<T, BooleanProperty> entry = it.next();
+            if (!rows.containsKey(entry.getKey())) {
+                droppedProperties.add(entry.getValue());
+                it.remove();
+            }
+        }
+
+        for (T item : rows.keySet()) {
+            if (itemRows != rows) {
+                // a listener of a property written above changed the item list, which indexed
+                // this model on it again: the rows left to walk here are those of a list which is
+                // gone, and the properties of the one the model now holds are that pass's to write
+                break;
+            }
             BooleanProperty property = itemBooleanMap.computeIfAbsent(item,
                     key -> new SimpleBooleanProperty(key, "selected", false)); //$NON-NLS-1$
             FollowedProperty followed = followedProperties.get(item);

--- a/controlsfx/src/main/java/org/controlsfx/control/CheckBitSetModelBase.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckBitSetModelBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2024, ControlsFX
+ * Copyright (c) 2013, 2026, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,26 +26,37 @@
  */
 package org.controlsfx.control;
 
-import impl.org.controlsfx.collections.MappingChange;
 import impl.org.controlsfx.collections.NonIterableChange;
 import impl.org.controlsfx.collections.ReadOnlyUnbackedObservableList;
 
+import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
+import java.util.Objects;
+import java.util.Set;
 
+/**
+ * Check model backed by a {@link BitSet} of the checked indices.
+ *
+ * <p>The check state belongs to the items: the rows holding equal items share a single
+ * {@link BooleanProperty}, so checking or clearing any of those rows reaches them all, and a
+ * change of the item list re-indexes the checks so that they stay on the items holding them.
+ * The observable lists of checked indices and items expose the state as last reported, so that
+ * a change handed to a listener stays readable whatever that listener does to the model.
+ */
 // not public API
-abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> { 
-    
+abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
+
     /***********************************************************************
      *                                                                     *
      * Internal properties                                                 *
@@ -53,13 +64,23 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
      **********************************************************************/
 
     private final Map<T, BooleanProperty> itemBooleanMap;
+    private final Map<T, FollowedProperty> followedProperties = new HashMap<>();
+    private Map<T, List<Integer>> itemRows = Collections.emptyMap();
 
-    private final BitSet checkedIndices;
-    private final BitSetReadOnlyUnbackedObservableList checkedIndicesList;
-    private final ReadOnlyUnbackedObservableList<T> checkedItemsList;
+    private final BitSet checkedIndices = new BitSet();
 
-    private AtomicBoolean listenerFlag = new AtomicBoolean();
-    
+    // the state as last reported. The lists are never mutated but replaced on each change, so
+    // that the sublists handed to the listeners stay readable; the BitSet tells the rows a change
+    // touched apart from the ones it left alone
+    private BitSet reportedIndices = new BitSet();
+    private List<Integer> checkedIndicesSnapshot = Collections.emptyList();
+    private List<T> checkedItemsSnapshot = Collections.emptyList();
+    // the checked items, each with the number of checked rows holding it
+    private Map<T, Integer> checkedRowCounts = new HashMap<>();
+
+    private final ReadOnlyUnbackedObservableList<Integer> checkedIndicesList = new CheckedIndicesList();
+    private final ReadOnlyUnbackedObservableList<T> checkedItemsList = new CheckedItemsList();
+
 
     /***********************************************************************
      *                                                                     *
@@ -69,65 +90,6 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
 
     CheckBitSetModelBase(final Map<T, BooleanProperty> itemBooleanMap) {
         this.itemBooleanMap = itemBooleanMap;
-
-        this.checkedIndices = new BitSet();
-        this.checkedIndicesList = new BitSetReadOnlyUnbackedObservableList(checkedIndices);
-        this.checkedItemsList = new ReadOnlyUnbackedObservableList<T>() {
-            @Override public T get(int i) {
-                int pos = checkedIndicesList.get(i);
-                if (pos < 0 || pos >= getItemCount()) return null;
-                return getItem(pos);
-            }
-
-            @Override public int size() {
-                return checkedIndices.cardinality();
-            }
-        };
-        
-        final MappingChange.Map<Integer,T> map = f -> getItem(f);
-        
-        checkedIndicesList.addListener((ListChangeListener<Integer>) c -> {
-            // when the selectedIndices ObservableList changes, we manually call
-            // the observers of the selectedItems ObservableList.
-            boolean hasRealChangeOccurred = false;
-            while (c.next() && ! hasRealChangeOccurred) {
-                hasRealChangeOccurred = c.wasAdded() || c.wasRemoved();
-            }
-
-            if (hasRealChangeOccurred) {
-                c.reset();
-                checkedItemsList.callObservers(new MappingChange<>(c, map, checkedItemsList));
-            }
-            c.reset();
-        });
-        
-        // this code is to handle the situation where a developer is manually
-        // toggling the check model, and expecting the UI to update (without
-        // this it won't happen!).
-        getCheckedItems().addListener((ListChangeListener<T>) c -> {
-            while (c.next()) {
-                if (c.wasAdded()) {
-                    for (T item : c.getAddedSubList()) {
-                        updateBooleanProperty(item, true);
-                    }
-                } 
-                
-                if (c.wasRemoved()) {
-                    for (T item : c.getRemoved()) {
-                        updateBooleanProperty(item, false);
-                    }
-                }
-            }
-        });
-    }
-
-    private void updateBooleanProperty(T item, boolean value) {
-        BooleanProperty p = getItemBooleanProperty(item);
-        if (p != null) {
-            listenerFlag.set(true);
-            p.set(value);
-            listenerFlag.set(false);
-        }
     }
 
 
@@ -139,24 +101,24 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
 
     @Override
     public abstract T getItem(int index);
-    
+
     @Override
     public abstract int getItemCount();
-    
+
     @Override
     public abstract int getItemIndex(T item);
-    
+
     BooleanProperty getItemBooleanProperty(T item) {
         return itemBooleanMap.get(item);
     }
-    
-    
+
+
     /***********************************************************************
      *                                                                     *
      * Public selection API                                                *
      *                                                                     *
      **********************************************************************/
-    
+
     /**
      * Returns a read-only list of the currently checked indices in the CheckBox.
      */
@@ -164,7 +126,7 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
     public ObservableList<Integer> getCheckedIndices() {
         return checkedIndicesList;
     }
-    
+
     /**
      * Returns a read-only list of the currently checked items in the CheckBox.
      */
@@ -176,68 +138,70 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
     /** {@inheritDoc} */
     @Override
     public void checkAll() {
-        for (int i = 0; i < getItemCount(); i++) {
-            check(i);
-        }
+        checkedIndices.set(0, getItemCount());
+        fireChanges();
     }
 
     /** {@inheritDoc} */
     @Override
     public void checkIndices(int... indices) {
         for (int index : indices) {
-            checkedIndices.set(index);
+            setRowsOf(index, true);
         }
-        ListChangeListener.Change<Integer> change = createRangeChange(checkedIndicesList, Arrays.stream(indices).boxed().collect(Collectors.toList()), false);
-        checkedIndicesList.callObservers(change);
-    }
-    
-    /** {@inheritDoc} */
-    @Override public void clearCheck(T item) {
-        int index = getItemIndex(item);
-        clearCheck(index);        
+        fireChanges();
     }
 
     /** {@inheritDoc} */
     @Override
-    public void clearChecks() {
-        List<Integer> removed = new BitSetReadOnlyUnbackedObservableList((BitSet) checkedIndices.clone());
-        checkedIndices.clear();
-        checkedIndicesList.callObservers(
-                new NonIterableChange.GenericAddRemoveChange<>(0, 0, removed, checkedIndicesList));
+    public void check(int index) {
+        setRowsOf(index, true);
+        fireChanges();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void check(T item) {
+        setItemChecked(item, true);
+        fireChanges();
     }
 
     /** {@inheritDoc} */
     @Override
     public void clearCheck(int index) {
-        if (index < 0 || index >= getItemCount()) return;
-        final int changeIndex = checkedIndicesList.indexOf(index);
-        checkedIndices.clear(index);
-        checkedIndicesList.callObservers(new NonIterableChange.SimpleRemovedChange<>(changeIndex, changeIndex, index, checkedIndicesList));
+        setRowsOf(index, false);
+        fireChanges();
     }
-    
+
+    /** {@inheritDoc} */
+    @Override
+    public void clearCheck(T item) {
+        setItemChecked(item, false);
+        fireChanges();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void clearChecks() {
+        checkedIndices.clear();
+        fireChanges();
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean isEmpty() {
         return checkedIndices.isEmpty();
     }
-    
-    /** {@inheritDoc} */
-    @Override public boolean isChecked(T item) {
-        int index = getItemIndex(item);
-        return isChecked(index);
-    }
 
     /** {@inheritDoc} */
     @Override
     public boolean isChecked(int index) {
-        return checkedIndices.get(index);
+        return isValidIndex(index) && checkedIndices.get(index);
     }
 
     /** {@inheritDoc} */
     @Override
-    public void toggleCheckState(T item) {
-        int index = getItemIndex(item);
-        toggleCheckState(index);
+    public boolean isChecked(T item) {
+        return checkedRowCounts.containsKey(item);
     }
 
     /** {@inheritDoc} */
@@ -252,50 +216,53 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
 
     /** {@inheritDoc} */
     @Override
-    public void check(int index) {
-        if (index < 0 || index >= getItemCount()) return;
-        checkedIndices.set(index);
-        final int changeIndex = checkedIndicesList.indexOf(index);
-        checkedIndicesList.callObservers(new NonIterableChange.SimpleAddChange<>(changeIndex, changeIndex+1, checkedIndicesList));
+    public void toggleCheckState(T item) {
+        if (isChecked(item)) {
+            clearCheck(item);
+        } else {
+            check(item);
+        }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void check(T item) {
-        int index = getItemIndex(item);
-        check(index);
-    }
-    
+
     /***********************************************************************
      *                                                                     *
-     * Private implementation                                              *
+     * Item list support                                                   *
      *                                                                     *
      **********************************************************************/
-    
+
+    /**
+     * Follows the current item list: indexes the rows of every item, keeps a
+     * {@link BooleanProperty} for each item of the list and re-indexes the checks so that they
+     * stay on the items holding them.
+     */
     protected void updateMap() {
-        // reset the map
-        itemBooleanMap.clear();
-        for (int i = 0; i < getItemCount(); i++) {
-            final int index = i;
-            final T item = getItem(index);
-
-            final BooleanProperty booleanProperty = new SimpleBooleanProperty(item, "selected", false); //$NON-NLS-1$
-            itemBooleanMap.put(item, booleanProperty);
-
-            // this is where we listen to changes to the boolean properties,
-            // updating the selected indices list (and therefore indirectly
-            // the selected items list) when the checkbox is toggled
-            booleanProperty.addListener(o -> {
-                if (!listenerFlag.get()) {
-                    if (booleanProperty.get()) {
-                        check(index);
-                    } else {
-                        clearCheck(index);
-                    }
-                }
-            });
+        Map<T, List<Integer>> rows = new HashMap<>();
+        for (int i = 0, count = getItemCount(); i < count; i++) {
+            rows.computeIfAbsent(getItem(i), item -> new ArrayList<>(1)).add(i);
         }
+        itemRows = rows;
+
+        checkedIndices.clear();
+        for (T item : checkedRowCounts.keySet()) {
+            setItemChecked(item, true);
+        }
+
+        updateFollowedProperties();
+        fireChangesAfterItemsChanged();
     }
+
+    /**
+     * Detaches this model from the item properties it drives. To be called by the control which
+     * replaces this model by another one built on the same properties.
+     */
+    void dispose() {
+        for (FollowedProperty followed : followedProperties.values()) {
+            followed.detach();
+        }
+        followedProperties.clear();
+    }
+
 
     /***********************************************************************
      *                                                                     *
@@ -303,182 +270,334 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
      *                                                                     *
      **********************************************************************/
 
-    private class BitSetReadOnlyUnbackedObservableList extends ReadOnlyUnbackedObservableList<Integer> {
-        private final BitSet bitset;
+    private boolean isValidIndex(int index) {
+        return index >= 0 && index < getItemCount();
+    }
 
-        private int lastGetIndex = -1;
-        private int lastGetValue = -1;
-
-        public BitSetReadOnlyUnbackedObservableList(BitSet bitset) {
-            this.bitset = bitset;
-        }
-
-        @Override public Integer get(int index) {
-            final int itemCount = getItemCount();
-            if (index < 0 || index >= itemCount)  {
-                return -1;
-            }
-
-            if (index == (lastGetIndex + 1)) {
-                // we're iterating forward in order, short circuit for
-                // performance reasons (RT-39776)
-                lastGetIndex++;
-                lastGetValue = bitset.nextSetBit(lastGetValue + 1);
-                return lastGetValue;
-            } else if (index == (lastGetIndex - 1) && index > 0) {
-                // we're iterating backward in order, short circuit for
-                // performance reasons (RT-39776)
-                lastGetIndex--;
-                lastGetValue = bitset.previousSetBit(lastGetValue - 1);
-                return lastGetValue;
-            } else {
-                for (lastGetIndex = 0, lastGetValue = bitset.nextSetBit(0);
-                     lastGetValue >= 0 || lastGetIndex == index;
-                     lastGetIndex++, lastGetValue = bitset.nextSetBit(lastGetValue + 1)) {
-                    if (lastGetIndex == index) {
-                        return lastGetValue;
-                    }
-                }
-            }
-
-            return -1;
-        }
-
-        @Override public int indexOf(Object obj) {
-            if (!(obj instanceof Number)) {
-                return -1;
-            }
-            Number n = (Number) obj;
-            int index = n.intValue();
-            if (!bitset.get(index)) {
-                return -1;
-            }
-
-            // is left most bit
-            if (index == 0) {
-                return 0;
-            }
-
-            // is right most bit
-            if (index == bitset.length() - 1) {
-                return size() - 1;
-            }
-
-            // count right bit
-            if (index > bitset.length() / 2) {
-                int count = 1;
-                for (int i = bitset.nextSetBit(index+1); i >= 0; i = bitset.nextSetBit(i+1)) {
-                    count++;
-                }
-                return size() - count;
-            }
-
-            // count left bit
-            int count = 0;
-            for (int i = bitset.previousSetBit(index-1);  i >= 0; i = bitset.previousSetBit(i-1)) {
-                count++;
-            }
-            return count;
-        }
-
-        @Override public int size() {
-            return bitset.cardinality();
-        }
-
-        @Override public boolean contains(Object o) {
-            if (o instanceof Number) {
-                Number n = (Number) o;
-                int index = n.intValue();
-
-                return index >= 0 && index < bitset.length() &&
-                        bitset.get(index);
-            }
-
-            return false;
-        }
-
-        public void reset() {
-            this.lastGetIndex = -1;
-            this.lastGetValue = -1;
+    /** Sets the check state of the given row along with every other row holding the same item. */
+    private void setRowsOf(int index, boolean checked) {
+        if (isValidIndex(index)) {
+            checkedIndices.set(index, checked);
+            setItemChecked(getItem(index), checked);
         }
     }
 
-    private static ListChangeListener.Change<Integer> createRangeChange(final ObservableList<Integer> list, final List<Integer> addedItems, boolean splitChanges) {
-        ListChangeListener.Change<Integer> change = new ListChangeListener.Change<Integer>(list) {
-            private final int[] EMPTY_PERM = new int[0];
-            private final int addedSize = addedItems.size();
-
-            private boolean invalid = true;
-
-            private int pos = 0;
-            private int from = pos;
-            private int to = pos;
-
-            @Override public int getFrom() {
-                checkState();
-                return from;
-            }
-
-            @Override public int getTo() {
-                checkState();
-                return to;
-            }
-
-            @Override public List<Integer> getRemoved() {
-                checkState();
-                return Collections.<Integer>emptyList();
-            }
-
-            @Override protected int[] getPermutation() {
-                checkState();
-                return EMPTY_PERM;
-            }
-
-            @Override public int getAddedSize() {
-                return to - from;
-            }
-
-            @Override public boolean next() {
-                if (pos >= addedSize) return false;
-
-                // starting from pos, we keep going until the value is
-                // not the next value
-                int startValue = addedItems.get(pos++);
-                from = list.indexOf(startValue);
-                to = from + 1;
-                int endValue = startValue;
-                while (pos < addedSize) {
-                    int previousEndValue = endValue;
-                    endValue = addedItems.get(pos++);
-                    ++to;
-                    if (splitChanges && previousEndValue != (endValue - 1)) {
-                        break;
-                    }
-                }
-
-                if (invalid) {
-                    invalid = false;
-                    return true;
-                }
-
-                // we keep going until we've represented all changes!
-                return splitChanges && pos < addedSize;
-            }
-
-            @Override public void reset() {
-                invalid = true;
-                pos = 0;
-                to = 0;
-                from = 0;
-            }
-
-            private void checkState() {
-                if (invalid) {
-                    throw new IllegalStateException("Invalid Change state: next() must be called before inspecting the Change.");
+    /** Sets the check state of every row holding the given item; returns whether any row changed. */
+    private boolean setItemChecked(T item, boolean checked) {
+        boolean changed = false;
+        List<Integer> rows = itemRows.get(item);
+        if (rows != null) {
+            for (int row : rows) {
+                if (checkedIndices.get(row) != checked) {
+                    checkedIndices.set(row, checked);
+                    changed = true;
                 }
             }
+        }
+        return changed;
+    }
 
-        };
-        return change;
+    private void onItemPropertyInvalidated(T item, BooleanProperty property) {
+        if (setItemChecked(item, property.get())) {
+            fireChanges();
+        }
+    }
+
+    private void updateFollowedProperties() {
+        for (Iterator<Map.Entry<T, FollowedProperty>> it = followedProperties.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<T, FollowedProperty> followed = it.next();
+            if (!itemRows.containsKey(followed.getKey())) {
+                followed.getValue().detach();
+                it.remove();
+            }
+        }
+        itemBooleanMap.keySet().retainAll(itemRows.keySet());
+
+        for (T item : itemRows.keySet()) {
+            BooleanProperty property = itemBooleanMap.computeIfAbsent(item,
+                    key -> new SimpleBooleanProperty(key, "selected", false)); //$NON-NLS-1$
+            FollowedProperty followed = followedProperties.get(item);
+            if (followed == null || followed.property != property) {
+                if (followed != null) {
+                    followed.detach();
+                }
+                followedProperties.put(item, new FollowedProperty(item, property));
+                property.set(isChecked(item));
+            }
+        }
+    }
+
+    /**
+     * Reports the rows checked or cleared since the state was last reported, the item list being
+     * the same as then. The rows a change left alone keep the position and the item they had,
+     * so the state as last reported is carried over and only the touched rows are looked at.
+     */
+    private void fireChanges() {
+        final BitSet changedRows = (BitSet) checkedIndices.clone();
+        changedRows.xor(reportedIndices);
+        if (changedRows.isEmpty()) {
+            return;
+        }
+
+        final List<Integer> previousIndices = checkedIndicesSnapshot;
+        final List<T> previousItems = checkedItemsSnapshot;
+        final int size = checkedIndices.cardinality();
+        final List<Integer> indices = new ArrayList<>(size);
+        final List<T> items = new ArrayList<>(size);
+        // for each item, the change of the number of checked rows holding it
+        final Map<T, Integer> rowCountDeltas = new HashMap<>();
+
+        int position = 0;
+        int from = -1;
+        for (int row = changedRows.nextSetBit(0); row >= 0; row = changedRows.nextSetBit(row + 1)) {
+            // the rows left alone below this one are carried over as they were
+            final int rowPosition = positionOf(previousIndices, position, row);
+            indices.addAll(previousIndices.subList(position, rowPosition));
+            items.addAll(previousItems.subList(position, rowPosition));
+            position = rowPosition;
+            if (from < 0) {
+                from = indices.size();
+            }
+            if (checkedIndices.get(row)) {
+                final T item = getItem(row);
+                indices.add(row);
+                items.add(item);
+                rowCountDeltas.merge(item, 1, Integer::sum);
+            } else {
+                // the row was checked as last reported, so it is the one at this position
+                rowCountDeltas.merge(previousItems.get(position), -1, Integer::sum);
+                position++;
+            }
+        }
+        final int tail = previousIndices.size() - position;
+        indices.addAll(previousIndices.subList(position, previousIndices.size()));
+        items.addAll(previousItems.subList(position, previousItems.size()));
+
+        final Set<T> affectedItems = new HashSet<>();
+        for (Map.Entry<T, Integer> delta : rowCountDeltas.entrySet()) {
+            final T item = delta.getKey();
+            final int before = checkedRowCounts.getOrDefault(item, 0);
+            final int after = before + delta.getValue();
+            if (after == 0) {
+                checkedRowCounts.remove(item);
+            } else {
+                checkedRowCounts.put(item, after);
+            }
+            if ((before == 0) != (after == 0)) {
+                affectedItems.add(item);
+            }
+        }
+
+        publish(indices, items, from, tail, from, tail, affectedItems);
+    }
+
+    /**
+     * Reports the difference between the state as last reported and the current one after a
+     * change of the item list. Such a change is free to leave the very same rows checked with
+     * other items sitting at them, so nothing of the state as last reported is carried over.
+     */
+    private void fireChangesAfterItemsChanged() {
+        final List<Integer> previousIndices = checkedIndicesSnapshot;
+        final List<T> previousItems = checkedItemsSnapshot;
+        final Map<T, Integer> previousRowCounts = checkedRowCounts;
+
+        final List<Integer> indices = new ArrayList<>(checkedIndices.cardinality());
+        final List<T> items = new ArrayList<>(indices.size());
+        final Map<T, Integer> rowCounts = new HashMap<>();
+        for (int i = checkedIndices.nextSetBit(0); i >= 0; i = checkedIndices.nextSetBit(i + 1)) {
+            final T item = getItem(i);
+            indices.add(i);
+            items.add(item);
+            rowCounts.merge(item, 1, Integer::sum);
+        }
+        checkedRowCounts = rowCounts;
+
+        final Set<T> affectedItems = new HashSet<>();
+        for (T item : previousRowCounts.keySet()) {
+            if (!rowCounts.containsKey(item)) {
+                affectedItems.add(item);
+            }
+        }
+        for (T item : rowCounts.keySet()) {
+            if (!previousRowCounts.containsKey(item)) {
+                affectedItems.add(item);
+            }
+        }
+
+        final int indicesFrom = commonPrefix(previousIndices, indices);
+        final int itemsFrom = commonPrefix(previousItems, items);
+        publish(indices, items,
+                indicesFrom, commonSuffix(previousIndices, indices, indicesFrom),
+                itemsFrom, commonSuffix(previousItems, items, itemsFrom),
+                affectedItems);
+    }
+
+    /**
+     * Takes the given state as the one last reported, reports what it changes of the previous
+     * one to the listeners of both lists, then aligns the properties of the items whose check
+     * state changed. Each list is reported the single replacement turning its previous content
+     * into the current one, past the positions left alone at its head ({@code from}) and at its
+     * tail ({@code tail}).
+     */
+    private void publish(List<Integer> indices, List<T> items,
+                         int indicesFrom, int indicesTail, int itemsFrom, int itemsTail,
+                         Set<T> affectedItems) {
+        final List<Integer> previousIndices = checkedIndicesSnapshot;
+        final List<T> previousItems = checkedItemsSnapshot;
+        final List<Integer> currentIndices = Collections.unmodifiableList(indices);
+        final List<T> currentItems = Collections.unmodifiableList(items);
+        reportedIndices = (BitSet) checkedIndices.clone();
+        checkedIndicesSnapshot = currentIndices;
+        checkedItemsSnapshot = currentItems;
+
+        // reported from the lists built here rather than from the fields: a listener told about
+        // the first change may change the model again, which moves the fields on
+        report(checkedIndicesList, previousIndices, currentIndices, indicesFrom, indicesTail);
+        report(checkedItemsList, previousItems, currentItems, itemsFrom, itemsTail);
+
+        // written last and to the current state: a listener above may have changed the model again
+        for (T item : affectedItems) {
+            FollowedProperty followed = followedProperties.get(item);
+            if (followed != null) {
+                followed.property.set(isChecked(item));
+            }
+        }
+    }
+
+    /** Reports the replacement of the elements of {@code previous} by the ones of {@code current} between the given common head and tail. */
+    private static <E> void report(ReadOnlyUnbackedObservableList<E> list, List<E> previous, List<E> current, int from, int tail) {
+        final List<E> removed = previous.subList(from, previous.size() - tail);
+        final List<E> added = current.subList(from, current.size() - tail);
+        if (!removed.isEmpty() || !added.isEmpty()) {
+            list.callObservers(new SnapshotChange<>(from, removed, added, list));
+        }
+    }
+
+    /**
+     * The position the given index holds, or would hold, in the given ascending list of indices,
+     * looking from the given position on.
+     */
+    private static int positionOf(List<Integer> indices, int from, int index) {
+        final int found = Collections.binarySearch(indices.subList(from, indices.size()), index);
+        return from + (found >= 0 ? found : -found - 1);
+    }
+
+    /** The number of leading elements the two lists have in common. */
+    private static <E> int commonPrefix(List<E> previous, List<E> current) {
+        final int common = Math.min(previous.size(), current.size());
+        int from = 0;
+        while (from < common && Objects.equals(previous.get(from), current.get(from))) {
+            from++;
+        }
+        return from;
+    }
+
+    /** The number of trailing elements the two lists have in common past their common prefix. */
+    private static <E> int commonSuffix(List<E> previous, List<E> current, int from) {
+        final int common = Math.min(previous.size(), current.size());
+        int tail = 0;
+        while (tail < common - from
+                && Objects.equals(previous.get(previous.size() - 1 - tail), current.get(current.size() - 1 - tail))) {
+            tail++;
+        }
+        return tail;
+    }
+
+
+    /***********************************************************************
+     *                                                                     *
+     * Support classes                                                     *
+     *                                                                     *
+     **********************************************************************/
+
+    /** The property of an item along with the listener through which this model follows it. */
+    private final class FollowedProperty {
+        private final BooleanProperty property;
+        private final InvalidationListener listener;
+
+        FollowedProperty(T item, BooleanProperty property) {
+            this.property = property;
+            this.listener = o -> onItemPropertyInvalidated(item, property);
+            property.addListener(listener);
+        }
+
+        void detach() {
+            property.removeListener(listener);
+        }
+    }
+
+    private final class CheckedIndicesList extends ReadOnlyUnbackedObservableList<Integer> {
+
+        /**
+         * {@inheritDoc}
+         *
+         * @return the checked index at the given position, or {@code -1} for a position which
+         *         holds none
+         */
+        @Override
+        public Integer get(int index) {
+            if (index < 0 || index >= checkedIndicesSnapshot.size()) {
+                return -1;
+            }
+            return checkedIndicesSnapshot.get(index);
+        }
+
+        @Override
+        public int size() {
+            return checkedIndicesSnapshot.size();
+        }
+
+        @Override
+        public int indexOf(Object o) {
+            if (!(o instanceof Number)) {
+                return -1;
+            }
+            final int position = Collections.binarySearch(checkedIndicesSnapshot, ((Number) o).intValue());
+            return position < 0 ? -1 : position;
+        }
+    }
+
+    private final class CheckedItemsList extends ReadOnlyUnbackedObservableList<T> {
+
+        /**
+         * {@inheritDoc}
+         *
+         * @return the checked item at the given position, or {@code null} for a position which
+         *         holds none
+         */
+        @Override
+        public T get(int index) {
+            if (index < 0 || index >= checkedItemsSnapshot.size()) {
+                return null;
+            }
+            return checkedItemsSnapshot.get(index);
+        }
+
+        @Override
+        public int size() {
+            return checkedItemsSnapshot.size();
+        }
+    }
+
+    /** A single replacement built from snapshots, readable whatever happens to the list afterwards. */
+    private static final class SnapshotChange<E> extends NonIterableChange.GenericAddRemoveChange<E> {
+        private final List<E> added;
+
+        SnapshotChange(int from, List<E> removed, List<E> added, ObservableList<E> list) {
+            super(from, from + added.size(), removed, list);
+            this.added = added;
+        }
+
+        @Override
+        public List<E> getAddedSubList() {
+            checkState();
+            return added;
+        }
+
+        @Override
+        public int getAddedSize() {
+            checkState();
+            return added.size();
+        }
     }
 }

--- a/controlsfx/src/main/java/org/controlsfx/control/CheckBitSetModelBase.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckBitSetModelBase.java
@@ -69,12 +69,17 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
 
     private final BitSet checkedIndices = new BitSet();
 
-    // the state as last reported. The lists are never mutated but replaced on each change, so
-    // that the sublists handed to the listeners stay readable; the BitSet tells the rows a change
-    // touched apart from the ones it left alone
-    private BitSet reportedIndices = new BitSet();
+    // the state the two lists expose, never mutated but replaced on each change, so that the
+    // sublists handed to the listeners stay readable
     private List<Integer> checkedIndicesSnapshot = Collections.emptyList();
     private List<T> checkedItemsSnapshot = Collections.emptyList();
+    // the rows checked as last reported, telling the rows a change touched apart from the ones
+    // it left alone
+    private BitSet reportedChecks = new BitSet();
+    // the content the listeners of each list hold, which a re-entrant change leaves further
+    // along than the change being reported
+    private List<Integer> lastReportedIndices = Collections.emptyList();
+    private List<T> lastReportedItems = Collections.emptyList();
     // the checked items, each with the number of checked rows holding it
     private Map<T, Integer> checkedRowCounts = new HashMap<>();
 
@@ -253,10 +258,18 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
     }
 
     /**
-     * Detaches this model from the item properties it drives. To be called by the control which
-     * replaces this model by another one built on the same properties.
+     * Attaches this model to the item list and to the item properties it drives, aligning them on
+     * the checks it holds. To be called by the control taking this model as its own.
      */
-    void dispose() {
+    void attach() {
+        updateMap();
+    }
+
+    /**
+     * Detaches this model from the item list and from the item properties it drives. To be called
+     * by the control dropping this model, be it for another one built on the same properties.
+     */
+    void detach() {
         for (FollowedProperty followed : followedProperties.values()) {
             followed.detach();
         }
@@ -304,10 +317,12 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
     }
 
     private void updateFollowedProperties() {
+        final List<BooleanProperty> droppedProperties = new ArrayList<>();
         for (Iterator<Map.Entry<T, FollowedProperty>> it = followedProperties.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<T, FollowedProperty> followed = it.next();
             if (!itemRows.containsKey(followed.getKey())) {
                 followed.getValue().detach();
+                droppedProperties.add(followed.getValue().property);
                 it.remove();
             }
         }
@@ -325,6 +340,12 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
                 property.set(isChecked(item));
             }
         }
+
+        // an item which left the list holds no check any more. Cleared once the map is up to
+        // date, as a listener of such a property is free to reach back into this model
+        for (BooleanProperty dropped : droppedProperties) {
+            dropped.set(false);
+        }
     }
 
     /**
@@ -334,7 +355,7 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
      */
     private void fireChanges() {
         final BitSet changedRows = (BitSet) checkedIndices.clone();
-        changedRows.xor(reportedIndices);
+        changedRows.xor(reportedChecks);
         if (changedRows.isEmpty()) {
             return;
         }
@@ -348,16 +369,12 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
         final Map<T, Integer> rowCountDeltas = new HashMap<>();
 
         int position = 0;
-        int from = -1;
         for (int row = changedRows.nextSetBit(0); row >= 0; row = changedRows.nextSetBit(row + 1)) {
             // the rows left alone below this one are carried over as they were
             final int rowPosition = positionOf(previousIndices, position, row);
             indices.addAll(previousIndices.subList(position, rowPosition));
             items.addAll(previousItems.subList(position, rowPosition));
             position = rowPosition;
-            if (from < 0) {
-                from = indices.size();
-            }
             if (checkedIndices.get(row)) {
                 final T item = getItem(row);
                 indices.add(row);
@@ -369,7 +386,6 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
                 position++;
             }
         }
-        final int tail = previousIndices.size() - position;
         indices.addAll(previousIndices.subList(position, previousIndices.size()));
         items.addAll(previousItems.subList(position, previousItems.size()));
 
@@ -388,7 +404,7 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
             }
         }
 
-        publish(indices, items, from, tail, from, tail, affectedItems);
+        publish(indices, items, affectedItems);
     }
 
     /**
@@ -397,8 +413,6 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
      * other items sitting at them, so nothing of the state as last reported is carried over.
      */
     private void fireChangesAfterItemsChanged() {
-        final List<Integer> previousIndices = checkedIndicesSnapshot;
-        final List<T> previousItems = checkedItemsSnapshot;
         final Map<T, Integer> previousRowCounts = checkedRowCounts;
 
         final List<Integer> indices = new ArrayList<>(checkedIndices.cardinality());
@@ -424,36 +438,28 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
             }
         }
 
-        final int indicesFrom = commonPrefix(previousIndices, indices);
-        final int itemsFrom = commonPrefix(previousItems, items);
-        publish(indices, items,
-                indicesFrom, commonSuffix(previousIndices, indices, indicesFrom),
-                itemsFrom, commonSuffix(previousItems, items, itemsFrom),
-                affectedItems);
+        publish(indices, items, affectedItems);
     }
 
     /**
-     * Takes the given state as the one last reported, reports what it changes of the previous
-     * one to the listeners of both lists, then aligns the properties of the items whose check
-     * state changed. Each list is reported the single replacement turning its previous content
-     * into the current one, past the positions left alone at its head ({@code from}) and at its
-     * tail ({@code tail}).
+     * Takes the given state as the current one, reports to the listeners of both lists what it
+     * changes of the content they hold, then aligns the properties of the affected items. Both
+     * lists are moved on before either is reported, so that a listener reads them in step.
      */
-    private void publish(List<Integer> indices, List<T> items,
-                         int indicesFrom, int indicesTail, int itemsFrom, int itemsTail,
-                         Set<T> affectedItems) {
-        final List<Integer> previousIndices = checkedIndicesSnapshot;
-        final List<T> previousItems = checkedItemsSnapshot;
-        final List<Integer> currentIndices = Collections.unmodifiableList(indices);
-        final List<T> currentItems = Collections.unmodifiableList(items);
-        reportedIndices = (BitSet) checkedIndices.clone();
-        checkedIndicesSnapshot = currentIndices;
-        checkedItemsSnapshot = currentItems;
+    private void publish(List<Integer> indices, List<T> items, Set<T> affectedItems) {
+        reportedChecks = (BitSet) checkedIndices.clone();
+        checkedIndicesSnapshot = Collections.unmodifiableList(indices);
+        checkedItemsSnapshot = Collections.unmodifiableList(items);
 
-        // reported from the lists built here rather than from the fields: a listener told about
-        // the first change may change the model again, which moves the fields on
-        report(checkedIndicesList, previousIndices, currentIndices, indicesFrom, indicesTail);
-        report(checkedItemsList, previousItems, currentItems, itemsFrom, itemsTail);
+        final List<Integer> previousIndices = lastReportedIndices;
+        lastReportedIndices = checkedIndicesSnapshot;
+        report(checkedIndicesList, previousIndices, lastReportedIndices);
+
+        // read after the indices are reported: a listener told about them may have changed the
+        // model, which reported the items list ahead of this one
+        final List<T> previousItems = lastReportedItems;
+        lastReportedItems = checkedItemsSnapshot;
+        report(checkedItemsList, previousItems, lastReportedItems);
 
         // written last and to the current state: a listener above may have changed the model again
         for (T item : affectedItems) {
@@ -464,8 +470,13 @@ abstract class CheckBitSetModelBase<T> implements IndexedCheckModel<T> {
         }
     }
 
-    /** Reports the replacement of the elements of {@code previous} by the ones of {@code current} between the given common head and tail. */
-    private static <E> void report(ReadOnlyUnbackedObservableList<E> list, List<E> previous, List<E> current, int from, int tail) {
+    /** Reports the single replacement turning {@code previous} into {@code current}, past the positions they have in common at their head and at their tail. */
+    private static <E> void report(ReadOnlyUnbackedObservableList<E> list, List<E> previous, List<E> current) {
+        if (previous == current) {
+            return;
+        }
+        final int from = commonPrefix(previous, current);
+        final int tail = commonSuffix(previous, current, from);
         final List<E> removed = previous.subList(from, previous.size() - tail);
         final List<E> added = current.subList(from, current.size() - tail);
         if (!removed.isEmpty() || !added.isEmpty()) {

--- a/controlsfx/src/main/java/org/controlsfx/control/CheckComboBox.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckComboBox.java
@@ -148,7 +148,10 @@ public class CheckComboBox<T> extends ControlsFXControl {
         this.items = items == null ? FXCollections.observableArrayList() : items;
         checkModelProperty().addListener((o, oldModel, newModel) -> {
             if (oldModel instanceof CheckBitSetModelBase) {
-                ((CheckBitSetModelBase<?>) oldModel).dispose();
+                ((CheckBitSetModelBase<?>) oldModel).detach();
+            }
+            if (newModel instanceof CheckBitSetModelBase) {
+                ((CheckBitSetModelBase<?>) newModel).attach();
             }
         });
         setCheckModel(new CheckComboBoxBitSetCheckModel<>(this.items, itemBooleanMap));
@@ -385,15 +388,22 @@ public class CheckComboBox<T> extends ControlsFXControl {
             super(itemBooleanMap);
             
             this.items = items;
-            this.items.addListener(itemsListener);
-            
-            updateMap();
+
+            attach();
         }
-        
+
         @Override
-        void dispose() {
+        void attach() {
+            // removed first: this model is attached again whenever it is set on its control
             items.removeListener(itemsListener);
-            super.dispose();
+            items.addListener(itemsListener);
+            super.attach();
+        }
+
+        @Override
+        void detach() {
+            items.removeListener(itemsListener);
+            super.detach();
         }
         
         

--- a/controlsfx/src/main/java/org/controlsfx/control/CheckComboBox.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckComboBox.java
@@ -146,6 +146,11 @@ public class CheckComboBox<T> extends ControlsFXControl {
         
         this.itemBooleanMap = new HashMap<>(initialSize);
         this.items = items == null ? FXCollections.observableArrayList() : items;
+        checkModelProperty().addListener((o, oldModel, newModel) -> {
+            if (oldModel instanceof CheckBitSetModelBase) {
+                ((CheckBitSetModelBase<?>) oldModel).dispose();
+            }
+        });
         setCheckModel(new CheckComboBoxBitSetCheckModel<>(this.items, itemBooleanMap));
     }
 
@@ -366,6 +371,7 @@ public class CheckComboBox<T> extends ControlsFXControl {
          **********************************************************************/
         
         private final ObservableList<T> items;
+        private final ListChangeListener<T> itemsListener = c -> updateMap();
         
         
         
@@ -379,9 +385,15 @@ public class CheckComboBox<T> extends ControlsFXControl {
             super(itemBooleanMap);
             
             this.items = items;
-            this.items.addListener((ListChangeListener<T>) c -> updateMap());
+            this.items.addListener(itemsListener);
             
             updateMap();
+        }
+        
+        @Override
+        void dispose() {
+            items.removeListener(itemsListener);
+            super.dispose();
         }
         
         

--- a/controlsfx/src/main/java/org/controlsfx/control/CheckListView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckListView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2019 ControlsFX
+ * Copyright (c) 2013, 2026 ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -126,6 +126,13 @@ public class CheckListView<T> extends ListView<T> {
         });
         setCheckModel(new CheckListViewBitSetCheckModel<>(getItems(), itemBooleanMap));
         itemsProperty().addListener(ov -> {
+            // detached before its replacement is built: the model dropped here holds the very
+            // properties that replacement writes as it indexes the new list, and an application
+            // still holding it would be told of checks the control no longer renders
+            final IndexedCheckModel<T> droppedModel = getCheckModel();
+            if (droppedModel instanceof CheckBitSetModelBase) {
+                ((CheckBitSetModelBase<?>) droppedModel).detach();
+            }
             setCheckModel(new CheckListViewBitSetCheckModel<>(getItems(), itemBooleanMap));
         });
         

--- a/controlsfx/src/main/java/org/controlsfx/control/CheckListView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckListView.java
@@ -116,6 +116,11 @@ public class CheckListView<T> extends ListView<T> {
         super(items);
         this.itemBooleanMap = new HashMap<>();
         
+        checkModelProperty().addListener((o, oldModel, newModel) -> {
+            if (oldModel instanceof CheckBitSetModelBase) {
+                ((CheckBitSetModelBase<?>) oldModel).dispose();
+            }
+        });
         setCheckModel(new CheckListViewBitSetCheckModel<>(getItems(), itemBooleanMap));
         itemsProperty().addListener(ov -> {
             setCheckModel(new CheckListViewBitSetCheckModel<>(getItems(), itemBooleanMap));
@@ -243,6 +248,7 @@ public class CheckListView<T> extends ListView<T> {
          **********************************************************************/
         
         private final ObservableList<T> items;
+        private final ListChangeListener<T> itemsListener = c -> updateMap();
         
         
         
@@ -255,10 +261,16 @@ public class CheckListView<T> extends ListView<T> {
         CheckListViewBitSetCheckModel(final ObservableList<T> items, final Map<T, BooleanProperty> itemBooleanMap) {
             super(itemBooleanMap);
             
-            this.items = items;
-            this.items.addListener((ListChangeListener<T>) c -> updateMap());
+            this.items = items == null ? FXCollections.emptyObservableList() : items;
+            this.items.addListener(itemsListener);
             
             updateMap();
+        }
+        
+        @Override
+        void dispose() {
+            items.removeListener(itemsListener);
+            super.dispose();
         }
         
         

--- a/controlsfx/src/main/java/org/controlsfx/control/CheckListView.java
+++ b/controlsfx/src/main/java/org/controlsfx/control/CheckListView.java
@@ -118,7 +118,10 @@ public class CheckListView<T> extends ListView<T> {
         
         checkModelProperty().addListener((o, oldModel, newModel) -> {
             if (oldModel instanceof CheckBitSetModelBase) {
-                ((CheckBitSetModelBase<?>) oldModel).dispose();
+                ((CheckBitSetModelBase<?>) oldModel).detach();
+            }
+            if (newModel instanceof CheckBitSetModelBase) {
+                ((CheckBitSetModelBase<?>) newModel).attach();
             }
         });
         setCheckModel(new CheckListViewBitSetCheckModel<>(getItems(), itemBooleanMap));
@@ -262,15 +265,22 @@ public class CheckListView<T> extends ListView<T> {
             super(itemBooleanMap);
             
             this.items = items == null ? FXCollections.emptyObservableList() : items;
-            this.items.addListener(itemsListener);
-            
-            updateMap();
+
+            attach();
         }
-        
+
         @Override
-        void dispose() {
+        void attach() {
+            // removed first: this model is attached again whenever it is set on its control
             items.removeListener(itemsListener);
-            super.dispose();
+            items.addListener(itemsListener);
+            super.attach();
+        }
+
+        @Override
+        void detach() {
+            items.removeListener(itemsListener);
+            super.detach();
         }
         
         

--- a/controlsfx/src/test/java/org/controlsfx/control/CheckBitSetModelBaseTest.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/CheckBitSetModelBaseTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, 2024, ControlsFX
+ * Copyright (c) 2022, 2026, ControlsFX
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
  */
 package org.controlsfx.control;
 
+import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -33,14 +34,21 @@ import javafx.collections.ObservableList;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.text.MessageFormat;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class CheckBitSetModelBaseTest {
@@ -54,6 +62,7 @@ public class CheckBitSetModelBaseTest {
     private static final String ROW_3_VALUE = "Row 3";
     private static final String ROW_4_VALUE = "Row 4";
     private static final String ROW_5_VALUE = "Row 5";
+    private static final String ROW_6_VALUE = "Row 6";
 
     @Before
     public void setUp() {
@@ -260,16 +269,14 @@ public class CheckBitSetModelBaseTest {
     @Test
     public void testCheckedItemsContainsCorrectValuesAfterCheckInOrder() {
         // derived from https://github.com/controlsfx/controlsfx/issues/1549
-        model.clearChecks();
-        assertTrue(model.isEmpty());
-
+        // Checking index 0 last does not expose the defect the tests below reproduce: the lookup
+        // shortcut of the checked indices list is only taken for indices greater than 0. This
+        // scenario therefore guards against a regression of the original issue.
         model.check(1);
         model.check(2);
         model.check(0);
 
-        assertTrue(model.isChecked(0));
-        assertTrue(model.isChecked(1));
-        assertTrue(model.isChecked(2));
+        assertOnlyCheckedIndicesAre(0, 1, 2);
     }
 
 
@@ -299,5 +306,620 @@ public class CheckBitSetModelBaseTest {
         assertFalse(model.isChecked(0));
         assertFalse(model.isChecked(1));
         assertTrue(model.isChecked(2));
+    }
+
+    @Test
+    public void testItemBooleanPropertiesAfterCheckingIntermediateIndexLast() {
+        // derived from https://github.com/controlsfx/controlsfx/issues/1549#issuecomment-5542131988
+        model.check(0);
+        model.check(2);
+        model.check(3);
+        model.check(1);
+
+        assertOnlyCheckedIndicesAre(0, 1, 2, 3);
+    }
+
+    @Test
+    public void testItemBooleanPropertiesAfterCheckingTheSameIndexTwice() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where the same index is
+        // checked twice - a no-op which still has to leave the model fit for the next check
+        model.check(0);
+        model.check(1);
+        model.check(1);
+        model.check(3);
+
+        assertOnlyCheckedIndicesAre(0, 1, 3);
+    }
+
+    @Test
+    public void testItemBooleanPropertiesAfterCheckIndicesOnIntermediateIndex() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 going through
+        // checkIndices(int...) instead of check(int)
+        model.check(0);
+        model.check(3);
+        model.check(4);
+        model.checkIndices(1);
+
+        assertOnlyCheckedIndicesAre(0, 1, 3, 4);
+    }
+
+    @Test
+    public void testItemBooleanPropertiesAfterClearCheckOnUncheckedIndex() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where an unchecked index
+        // is cleared - a no-op on the check model - before an intermediate index is checked
+        model.check(0);
+        model.check(3);
+        model.check(4);
+        model.clearCheck(1);
+        model.check(2);
+
+        assertOnlyCheckedIndicesAre(0, 2, 3, 4);
+    }
+
+    @Test
+    public void testItemBooleanPropertiesAfterCheckIndicesNotInAscendingOrder() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where the indices
+        // handed to checkIndices(int...) are in descending order
+        model.checkIndices(4, 0);
+
+        assertOnlyCheckedIndicesAre(0, 4);
+    }
+
+    @Test
+    public void testItemBooleanPropertiesAfterCheckIndicesWithDuplicateIndex() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where the same index is
+        // handed twice to checkIndices(int...)
+        model.checkIndices(4, 4);
+
+        assertOnlyCheckedIndicesAre(4);
+    }
+
+    @Test
+    public void testItemBooleanPropertiesAfterCheckIndicesAroundAnAlreadyCheckedIndex() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where the indices handed
+        // to checkIndices(int...) surround an already checked index. The added indices are then
+        // spread over two runs of the checked indices list, each of which has to be reported.
+        model.check(2);
+        model.checkIndices(0, 4);
+
+        assertOnlyCheckedIndicesAre(0, 2, 4);
+    }
+
+    @Test
+    public void testItemBooleanPropertiesAfterAnItemIsAddedToTheList() {
+        // adding an item makes the check model follow the change of the item list
+        model.check(1);
+
+        items.add(ROW_6_VALUE);
+
+        assertOnlyCheckedIndicesAre(1);
+    }
+
+    @Test
+    public void testCheckIndicesIgnoresNegativeIndex() {
+        model.checkIndices(-1);
+
+        assertOnlyCheckedIndicesAre();
+    }
+
+    @Test
+    public void testCheckIndicesIgnoresIndexBeyondItemCount() {
+        model.checkIndices(items.size());
+
+        assertOnlyCheckedIndicesAre();
+    }
+
+    @Test
+    public void testCheckedIndicesKeepReportingTheSameValueBeyondTheCheckedCount() {
+        // an index between size() and getItemCount() is not backed by any checked index: get(int)
+        // answers -1 for it, and has to keep doing so however many times it is asked
+        model.check(0);
+        model.check(1);
+
+        ObservableList<Integer> checkedIndices = model.getCheckedIndices();
+        assertEquals("Unexpected value beyond the checked count",
+            Integer.valueOf(-1), checkedIndices.get(3));
+        assertEquals("Unexpected value beyond the checked count",
+            Integer.valueOf(-1), checkedIndices.get(4));
+        assertEquals("Unexpected value beyond the checked count, read a second time",
+            Integer.valueOf(-1), checkedIndices.get(3));
+    }
+
+    @Test
+    public void testCheckedIndicesAreCorrectAfterAReadBeyondTheCheckedCount() {
+        // reading an index beyond the checked count must not disturb the iteration state get(int)
+        // caches, otherwise the next read of a valid index is computed from a stale state
+        model.check(0);
+        model.check(1);
+
+        ObservableList<Integer> checkedIndices = model.getCheckedIndices();
+        assertEquals(Integer.valueOf(-1), checkedIndices.get(3));
+        assertEquals("Unexpected checked index at position 1",
+            Integer.valueOf(1), checkedIndices.get(1));
+    }
+
+    @Test
+    public void testClearCheckOnAnUncheckedIndexReportsNoChange() {
+        // clearing an unchecked index is a no-op on the check model, so it must not report a
+        // removal: there is no position in the checked indices list such a change could describe
+        model.check(0);
+        model.check(2);
+        List<String> changes = recordChangesOfCheckedIndices();
+
+        model.clearCheck(1);
+
+        assertEquals("Unexpected change reported for an unchanged check model",
+            Collections.<String>emptyList(), changes);
+    }
+
+    @Test
+    public void testCheckOnAnAlreadyCheckedIndexReportsNoChange() {
+        // checking an already checked index is a no-op on the check model, so it must not report
+        // an addition: the index is already part of the checked indices list
+        model.check(1);
+        List<String> changes = recordChangesOfCheckedIndices();
+
+        model.check(1);
+
+        assertEquals("Unexpected change reported for an unchanged check model",
+            Collections.<String>emptyList(), changes);
+    }
+
+    @Test
+    public void testIsCheckedOnAnItemWhichIsNotInTheList() {
+        assertFalse(model.isChecked("Not in the list"));
+    }
+
+    @Test
+    public void testRemovingACheckedItemKeepsTheOtherChecks() {
+        model.check(0);
+        model.check(4);
+
+        items.remove(4);
+
+        assertOnlyCheckedIndicesAre(0);
+    }
+
+    @Test
+    public void testACheckFollowsItsItemWhenAnEarlierItemIsRemoved() {
+        // the check made on ROW_5_VALUE, at index 4, moves down to index 3 with it
+        model.check(4);
+
+        items.remove(0);
+
+        assertOnlyCheckedIndicesAre(3);
+    }
+
+    @Test
+    public void testRemovingACheckedItemReportsTheCheckItTakesAway() {
+        // the check made on ROW_5_VALUE dies with the item, and a listener of the checked indices
+        // has to be told about it, otherwise it goes on showing a check the model no longer holds
+        model.check(4);
+        List<Integer> observedCheckedIndices = observe(model.getCheckedIndices());
+
+        items.remove(4);
+
+        assertEquals("The reported changes do not add up to the checked indices",
+            new ArrayList<>(model.getCheckedIndices()), observedCheckedIndices);
+    }
+
+    @Test
+    public void testRemovingAnItemBeforeACheckedItemReportsTheReindexedCheck() {
+        // the check made on ROW_5_VALUE moves down from index 4 to index 3 with it: a listener
+        // which was told index 4 is checked has to be told it is now index 3
+        model.check(4);
+        List<Integer> observedCheckedIndices = observe(model.getCheckedIndices());
+
+        items.remove(0);
+
+        assertEquals("The reported changes do not add up to the checked indices",
+            new ArrayList<>(model.getCheckedIndices()), observedCheckedIndices);
+    }
+
+    @Test
+    public void testRemovingACheckedItemReportsAChangeOfTheCheckedItems() {
+        // CheckComboBoxSkin refreshes the text of its button from a listener of the checked items,
+        // and so keeps rendering an item which is gone until that change is reported
+        model.check(4);
+        AtomicInteger count = new AtomicInteger();
+        model.getCheckedItems().addListener((ListChangeListener<String>) change -> count.getAndIncrement());
+
+        items.remove(4);
+
+        assertEquals("Expected the check the removed item takes away to be reported once",
+            1, count.get());
+    }
+
+    @Test
+    public void testTheBooleanPropertyOfAnItemFollowsItsCheckAfterAnItemIsAdded() {
+        // getItemBooleanProperty(T) is public API, handed out to be bound to: the property given
+        // for an item has to go on following the checks made on that item, whatever happens to the
+        // list of items. This is how the CheckBox of a CheckListView row holds it.
+        BooleanProperty rowProperty = model.getItemBooleanProperty(ROW_2_VALUE);
+
+        items.add(ROW_6_VALUE);
+        model.check(1);
+
+        assertTrue("The property handed out for the item no longer follows its check",
+            rowProperty.get());
+    }
+
+    @Test
+    public void testClearChecksOnAnUncheckedModelReportsNoChange() {
+        List<String> changes = recordChangesOfCheckedIndices();
+
+        model.clearChecks();
+
+        assertEquals("Unexpected change reported for an unchanged check model",
+            Collections.<String>emptyList(), changes);
+    }
+
+    @Test
+    public void testCheckAllCallsListenerOnce() {
+        AtomicInteger count = new AtomicInteger();
+        model.getCheckedItems().addListener((ListChangeListener<String>) change -> {
+            count.getAndIncrement();
+        });
+
+        model.checkAll();
+
+        assertEquals("Expected a single change for the whole check", 1, count.get());
+        assertOnlyCheckedIndicesAre(0, 1, 2, 3, 4);
+    }
+
+    @Test
+    public void testTheBooleanPropertyOfAnItemDrivesTheCheckModelBuiltAfterIt() {
+        // a control which replaces its list of items builds a new check model around the very
+        // same item boolean map, and the properties already handed out live on in that map: the
+        // check box bound to one of them has to go on driving the check model the control holds
+        CheckBitSetModelBase<String> newModel =
+            new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+
+        newModel.getItemBooleanProperty(ROW_2_VALUE).set(true);
+
+        assertTrue("The check box of the item no longer drives the check model built after it",
+            newModel.isChecked(1));
+    }
+
+    @Test
+    public void testTheBooleanPropertyOfADuplicatedItemKeepsTheCheckWhichSurvives() {
+        // two equal items are two rows, each holding its own check, but a single BooleanProperty:
+        // once one of the rows is gone, that property has to stand for the check the other keeps
+        this.itemBooleanMap = new HashMap<>();
+        this.items = FXCollections.observableArrayList(ROW_1_VALUE, ROW_1_VALUE);
+        model = new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+        model.check(0);
+        model.check(1);
+
+        items.remove(0);
+
+        assertOnlyCheckedIndicesAre(0);
+    }
+
+    @Test
+    public void testACheckWhichFollowedItsItemIsNotToggledAlongTheWay() {
+        // a change of the item list reindexes the checks, it does not undo and redo them: an
+        // application bound to the property of a still checked item must not be told otherwise
+        model.check(1);
+        model.check(3);
+        List<Boolean> reportedValues = new ArrayList<>();
+        model.getItemBooleanProperty(ROW_2_VALUE)
+            .addListener((o, wasChecked, isChecked) -> reportedValues.add(isChecked));
+
+        items.remove(0);
+
+        assertEquals("Unexpected change reported on a check the removal left untouched",
+            Collections.<Boolean>emptyList(), reportedValues);
+    }
+
+    @Test
+    public void testCheckingFromTheBooleanPropertyOfARemovedItemReportsCoherentChanges() {
+        // the property of an item is handed out to be bound to, and whoever listens to it is free
+        // to check another item when it changes - the model is then asked to check while it is
+        // still following a change of the item list, and what it reports has to hold all the same
+        model.check(0);
+        model.check(4);
+        model.getItemBooleanProperty(ROW_1_VALUE).addListener((o, wasChecked, isChecked) -> {
+            if (!isChecked) {
+                model.check(1);
+            }
+        });
+        List<Integer> observedCheckedIndices = observe(model.getCheckedIndices());
+
+        items.remove(0);
+
+        assertEquals("The reported changes do not add up to the checked indices",
+            new ArrayList<>(model.getCheckedIndices()), observedCheckedIndices);
+    }
+
+    @Test
+    public void testReorderingTheItemsReportsTheChangeItMakesToTheCheckedItems() {
+        // the sort swaps the two checked items, so it leaves the very same indices checked but
+        // not the same items sitting at them: CheckComboBoxSkin renders the checked items, and
+        // goes on rendering the ones it was last told about until that change is reported
+        model.check(0);
+        model.check(4);
+        List<String> observedCheckedItems = observe(model.getCheckedItems());
+
+        items.sort(Comparator.reverseOrder());
+
+        assertEquals("The reported changes do not add up to the checked items",
+            new ArrayList<>(model.getCheckedItems()), observedCheckedItems);
+    }
+
+    @Test
+    public void testClearingACheckIsNotUndoneByTheCheckMadeFromItsBooleanProperty() {
+        // whoever holds the property of an item is free to check another one when it changes, so
+        // the model ends up writing a property from within the write of that very property: what
+        // it writes there must not be read back, once the outer write resumes, as the user
+        // toggling the check box that property stands for
+        model.check(0);
+        final BooleanProperty itemBooleanProperty = model.getItemBooleanProperty(ROW_1_VALUE);
+        // an InvalidationListener, which is what a binding on that property registers, and which
+        // is notified in the order it was added - ahead of every ChangeListener
+        itemBooleanProperty.addListener((InvalidationListener) o -> {
+            if (!itemBooleanProperty.get()) {
+                model.check(1);
+            }
+        });
+        // a change of the item list has the model go over the property of every item again, and
+        // must leave it listening ahead of the application all the same
+        items.add(ROW_6_VALUE);
+
+        model.clearCheck(0);
+
+        assertOnlyCheckedIndicesAre(1);
+    }
+
+    @Test
+    public void testClearingOneOfTheRowsOfADuplicatedItemClearsThemBoth() {
+        // the rows holding equal items share a single check box, so clearing either of them has
+        // to reach them both - as checking either of them does - otherwise the check box goes on
+        // rendering a check the model only holds on the other row
+        this.itemBooleanMap = new HashMap<>();
+        this.items = FXCollections.observableArrayList(ROW_1_VALUE, ROW_1_VALUE, ROW_2_VALUE);
+        model = new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+        model.check(0);
+
+        model.clearCheck(0);
+
+        assertOnlyCheckedIndicesAre();
+        assertFalse("The item is still reported checked", model.isChecked(ROW_1_VALUE));
+    }
+
+    @Test
+    public void testTogglingOneOfTheRowsOfADuplicatedItemClearsThemBoth() {
+        // toggleCheckState(int) on a checked row goes through clearCheck(int), and has to leave
+        // the other row of the item unchecked along with it
+        this.itemBooleanMap = new HashMap<>();
+        this.items = FXCollections.observableArrayList(ROW_1_VALUE, ROW_1_VALUE, ROW_2_VALUE);
+        model = new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+        model.check(1);
+
+        model.toggleCheckState(0);
+
+        assertOnlyCheckedIndicesAre();
+    }
+
+    @Test
+    public void testCheckedItemsAnswerNullBeyondTheCheckedCount() {
+        // getCheckedItems().get(int) has always answered null for a position it does not hold,
+        // as getCheckedIndices().get(int) answers -1: callers walking the two lists side by side
+        // rely on neither of them throwing
+        model.check(0);
+        model.check(1);
+
+        assertEquals("Unexpected item beyond the checked count", null, model.getCheckedItems().get(3));
+    }
+
+    @Test
+    public void testAChangeOfTheCheckedItemsCanBeReadByEveryListenerItReaches() {
+        // the model writes the item boolean properties while the change of the checked items is
+        // being reported, and whoever holds one of them is free to check or clear items from
+        // there: the change already handed out has to go on reporting what it was built with,
+        // whatever the model holds by the time the next listener reads it
+        List<String> failures = new ArrayList<>();
+        model.getItemBooleanProperty(ROW_1_VALUE).addListener((o, wasChecked, isChecked) -> {
+            if (isChecked) {
+                model.clearChecks();
+            }
+        });
+        model.getCheckedItems().addListener((ListChangeListener<String>) change -> {
+            try {
+                while (change.next()) {
+                    change.getRemoved();
+                    change.getAddedSubList();
+                }
+            } catch (RuntimeException e) {
+                failures.add(e.toString());
+            }
+        });
+
+        model.checkAll();
+
+        assertEquals("A listener was given a change of the checked items it cannot read",
+            Collections.<String>emptyList(), failures);
+    }
+
+    @Test
+    public void testSettingTheSameItemsAgainKeepsTheChecks() {
+        // an application which refetches its data and hands the very same items back has changed
+        // nothing of what the user sees: the checks it made are still on the rows holding them
+        model.check(1);
+
+        items.setAll(ROW_1_VALUE, ROW_2_VALUE, ROW_3_VALUE, ROW_4_VALUE, ROW_5_VALUE);
+
+        assertOnlyCheckedIndicesAre(1);
+    }
+
+    @Test
+    public void testCheckingOneOfTheRowsOfADuplicatedItemChecksThemBoth() {
+        // two equal items share a single BooleanProperty, and therefore a single check box - see
+        // CheckComboBox.getItemBooleanProperty(T): the model cannot hold one of those rows
+        // checked and the other not, as the check box standing for both would then render a
+        // check the model denies
+        this.itemBooleanMap = new HashMap<>();
+        this.items = FXCollections.observableArrayList(ROW_1_VALUE, ROW_1_VALUE, ROW_2_VALUE);
+        model = new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+
+        model.check(1);
+
+        assertOnlyCheckedIndicesAre(0, 1);
+    }
+
+    @Test
+    public void testTheCheckedIndicesAnswerNoPositionForAValueTheyDoNotHold() {
+        // getCheckedIndices().get(int) answers -1 for a position beyond the checks it holds, and
+        // that -1 goes straight back into indexOf whenever a caller round-trips a value through
+        // the list
+        model.check(2);
+
+        assertEquals("Unexpected position answered for a value the checked indices do not hold",
+            -1, model.getCheckedIndices().indexOf(-1));
+    }
+
+    @Test
+    public void testCheckingFromTheBooleanPropertyOfAnItemChecksEveryRowOfADuplicatedItem() {
+        // whoever holds the property of an item is free to check another one when it changes, and
+        // the check made from there is a check like any other: the rows holding equal items share
+        // a single check box, so a check on either of them has to reach them both
+        this.itemBooleanMap = new HashMap<>();
+        this.items = FXCollections.observableArrayList(ROW_1_VALUE, ROW_2_VALUE, ROW_2_VALUE);
+        model = new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+        model.getItemBooleanProperty(ROW_1_VALUE).addListener((o, wasChecked, isChecked) -> {
+            if (isChecked) {
+                model.check(1);
+            }
+        });
+
+        model.check(0);
+
+        assertOnlyCheckedIndicesAre(0, 1, 2);
+    }
+
+    @Test
+    public void testTheChecksFollowTheirItemsWhenTheItemListChangesAgainFromTheirReport() {
+        // whoever is told about the reindexed checks is free to change the item list again from
+        // there, and the checks have to follow that change as they follow any other: a list which
+        // is changed again while it is still reporting hands the model the range it already
+        // followed along with the new one
+        model.check(1);
+        model.check(3);
+        AtomicInteger reportedChanges = new AtomicInteger();
+        model.getCheckedItems().addListener((ListChangeListener<String>) change -> {
+            if (reportedChanges.getAndIncrement() == 0) {
+                items.remove(ROW_5_VALUE);
+            }
+        });
+
+        items.remove(ROW_1_VALUE);
+
+        // neither of the removed items was ever checked, so the checks of ROW_2 and ROW_4 are
+        // still theirs - at the positions the two removals leave them at
+        assertOnlyCheckedIndicesAre(0, 2);
+    }
+
+    @Test
+    public void testClearingEveryCheckFromTheReportOfACheckLeavesNoCheckBoxChecked() {
+        // a listener of the checked indices is free to clear the checks from there, which leaves
+        // the change still being reported standing for a check the model no longer holds: what
+        // the check boxes render has to be the checks the model ends up with, not that one
+        model.check(2);
+        AtomicInteger reportedChanges = new AtomicInteger();
+        model.getCheckedIndices().addListener((ListChangeListener<Integer>) change -> {
+            if (reportedChanges.getAndIncrement() == 0) {
+                model.clearChecks();
+            }
+        });
+
+        model.check(4);
+
+        assertOnlyCheckedIndicesAre();
+    }
+
+    /**
+     * Returns a copy of the given list of checks - {@link IndexedCheckModel#getCheckedIndices()}
+     * or {@link IndexedCheckModel#getCheckedItems()} - kept up to date from the changes that list
+     * reports from now on. The copy drifting away from the list itself is the only thing a
+     * listener can see of a change which was never reported, or reported wrong.
+     */
+    private <E> List<E> observe(ObservableList<E> checks) {
+        final List<E> observed = new ArrayList<>(checks);
+        checks.addListener((ListChangeListener<E>) change -> {
+            while (change.next()) {
+                if (change.wasPermutated()) {
+                    List<E> permutated = new ArrayList<>(observed.subList(change.getFrom(), change.getTo()));
+                    for (int i = change.getFrom(); i < change.getTo(); i++) {
+                        observed.set(change.getPermutation(i), permutated.get(i - change.getFrom()));
+                    }
+                } else {
+                    observed.subList(change.getFrom(), change.getFrom() + change.getRemovedSize()).clear();
+                    observed.addAll(change.getFrom(), change.getAddedSubList());
+                }
+            }
+        });
+        return observed;
+    }
+
+    /**
+     * Records a description of every change {@link IndexedCheckModel#getCheckedIndices()} reports
+     * from now on. Asserting on those descriptions rather than on a list rebuilt from the changes
+     * is deliberate: JavaFX hands the exceptions thrown by a {@link ListChangeListener} over to the
+     * uncaught exception handler of the thread, so a listener choking on a malformed change would
+     * go unnoticed.
+     */
+    private List<String> recordChangesOfCheckedIndices() {
+        final List<String> changes = new ArrayList<>();
+        model.getCheckedIndices().addListener((ListChangeListener<Integer>) change -> {
+            while (change.next()) {
+                StringBuilder description = new StringBuilder();
+                description.append("from ").append(change.getFrom()).append(" to ").append(change.getTo());
+                if (change.wasRemoved()) {
+                    description.append(", removed ").append(change.getRemoved());
+                }
+                if (change.wasAdded()) {
+                    description.append(", added ").append(change.getAddedSubList());
+                }
+                changes.add(description.toString());
+            }
+        });
+        return changes;
+    }
+
+    /**
+     * Asserts that exactly the given indices are checked, both in the check model and in the
+     * {@link BooleanProperty} of every item - the property each check box is bound to, and
+     * therefore what the user actually sees.
+     */
+    private void assertOnlyCheckedIndicesAre(int... expectedCheckedIndices) {
+        BitSet expected = new BitSet();
+        for (int index : expectedCheckedIndices) {
+            expected.set(index);
+        }
+
+        for (int index = 0; index < items.size(); index++) {
+            boolean shouldBeChecked = expected.get(index);
+            String state = shouldBeChecked ? "checked" : "not checked";
+
+            assertEquals(
+                MessageFormat.format("Expected index {0} to be {1} in the check model", index, state),
+                shouldBeChecked, model.isChecked(index));
+
+            BooleanProperty itemBooleanProperty = model.getItemBooleanProperty(items.get(index));
+            assertNotNull(
+                MessageFormat.format("Expected a BooleanProperty for index {0}", index),
+                itemBooleanProperty);
+            assertEquals(
+                MessageFormat.format("Expected the check box of index {0} to be {1}", index, state),
+                shouldBeChecked, itemBooleanProperty.get());
+        }
+
+        List<Integer> expectedIndices = expected.stream().boxed().collect(Collectors.toList());
+        assertEquals("Unexpected checked indices",
+            expectedIndices, new ArrayList<>(model.getCheckedIndices()));
+
+        List<String> expectedItems = expected.stream().mapToObj(items::get).collect(Collectors.toList());
+        assertEquals("Unexpected checked items",
+            expectedItems, new ArrayList<>(model.getCheckedItems()));
     }
 }

--- a/controlsfx/src/test/java/org/controlsfx/control/CheckBitSetModelBaseTest.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/CheckBitSetModelBaseTest.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class CheckBitSetModelBaseTest {
@@ -870,6 +871,106 @@ public class CheckBitSetModelBaseTest {
 
         assertEquals("The reported changes do not add up to the checked items",
             Collections.<String>emptyList(), observedCheckedItems);
+    }
+
+    @Test
+    public void testCheckingThroughADetachedModelLeavesTheRowsOfItsFormerListAlone() {
+        // a control which replaces its list of items detaches the model it drops, and that model
+        // goes on holding the rows it had indexed: a check made through it must not reach a row
+        // the list no longer has - the model reads the item of every row it reports a check for
+        this.itemBooleanMap = new HashMap<>();
+        this.items = FXCollections.observableArrayList(ROW_1_VALUE, ROW_2_VALUE, ROW_1_VALUE);
+        model = new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+        model.detach();
+        items.remove(2);
+
+        model.check(0);
+
+        assertEquals("The check reached a row beyond the end of the item list",
+            Collections.singletonList(0), new ArrayList<>(model.getCheckedIndices()));
+    }
+
+    @Test
+    public void testTheBooleanPropertyOfACheckedItemIsClearedWhenAModelIsBuiltOnAnotherList() {
+        // a control which replaces its list of items builds a new check model around the very
+        // same item boolean map, and the properties already handed out live on in that map: an
+        // item which is not in the new list holds no check any more, so the property standing
+        // for it must not go on reporting the one it had
+        BooleanProperty rowProperty = model.getItemBooleanProperty(ROW_1_VALUE);
+        model.check(0);
+
+        new CheckComboBox.CheckComboBoxBitSetCheckModel<>(
+            FXCollections.observableArrayList(ROW_6_VALUE), itemBooleanMap);
+
+        assertFalse("The property handed out for an item of the former list still reports its check",
+            rowProperty.get());
+    }
+
+    @Test
+    public void testAReportedChangeStaysReadableByTheListenersItHasYetToReach() {
+        // a listener of the checked indices is free to clear the checks from there, which leaves
+        // the change being reported standing for checks the model no longer holds: the listeners
+        // that change has yet to reach must still be able to read it, whatever the model now holds
+        model.check(2);
+        AtomicInteger reportedChanges = new AtomicInteger();
+        model.getCheckedIndices().addListener((ListChangeListener<Integer>) change -> {
+            if (reportedChanges.getAndIncrement() == 0) {
+                model.clearChecks();
+            }
+        });
+        List<String> failures = new ArrayList<>();
+        model.getCheckedIndices().addListener((ListChangeListener<Integer>) change -> {
+            try {
+                String.valueOf(change);
+            } catch (RuntimeException e) {
+                failures.add(e.toString());
+            }
+        });
+
+        model.check(4);
+
+        assertEquals("A reported change could not be read",
+            Collections.<String>emptyList(), failures);
+    }
+
+    @Test
+    public void testAnItemIsNoLongerCheckedWhenTheModelClearsItsBooleanProperty() {
+        // the property of an item stands for the check the model holds on it, and a listener of
+        // that property is free to reach back into the model: what the model answers there has to
+        // be what the property reports, not the check the item held before it left the list
+        BooleanProperty rowProperty = model.getItemBooleanProperty(ROW_1_VALUE);
+        model.check(0);
+        List<Boolean> reportedByTheModel = new ArrayList<>();
+        rowProperty.addListener(o -> reportedByTheModel.add(model.isChecked(ROW_1_VALUE)));
+
+        items.remove(ROW_1_VALUE);
+
+        assertEquals("The model reports a check for the item whose property it is clearing",
+            Collections.singletonList(false), reportedByTheModel);
+    }
+
+    @Test
+    public void testNoBooleanPropertyIsLeftBehindWhenTheItemsChangeWhileTheModelIsIndexingThem() {
+        // a listener of an item property is free to change the list of items from there, which
+        // re-indexes the model while it is walking the very items it is indexing: whatever that
+        // listener leaves in the list, no property may be left behind for an item which is gone,
+        // as getItemBooleanProperty(T) would hand it out as the property of an item of the list
+        this.itemBooleanMap = new HashMap<>();
+        this.items = FXCollections.observableArrayList(ROW_1_VALUE, ROW_2_VALUE);
+        model = new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+        model.checkAll();
+        model.getItemBooleanProperty(ROW_1_VALUE).addListener(o -> items.clear());
+        model.getItemBooleanProperty(ROW_2_VALUE).addListener(o -> items.clear());
+
+        // the control replaces its list of items: the model built for the new one clears the
+        // properties of the checks it does not hold, and the listeners above empty the list
+        CheckBitSetModelBase<String> newModel =
+            new CheckComboBox.CheckComboBoxBitSetCheckModel<>(items, itemBooleanMap);
+
+        assertNull("A property is left behind for an item which is no longer in the list",
+            newModel.getItemBooleanProperty(ROW_1_VALUE));
+        assertNull("A property is left behind for an item which is no longer in the list",
+            newModel.getItemBooleanProperty(ROW_2_VALUE));
     }
 
     /**

--- a/controlsfx/src/test/java/org/controlsfx/control/CheckBitSetModelBaseTest.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/CheckBitSetModelBaseTest.java
@@ -545,6 +545,20 @@ public class CheckBitSetModelBaseTest {
     }
 
     @Test
+    public void testTheBooleanPropertyOfACheckedItemIsClearedWhenThatItemLeavesTheList() {
+        // the property of an item is public API, handed out to be bound to, and it stands for the
+        // check the model holds on that item: an item taken out of the list holds no check any
+        // more, so whoever is bound to its property must not go on rendering the one it had
+        BooleanProperty rowProperty = model.getItemBooleanProperty(ROW_5_VALUE);
+        model.check(4);
+
+        items.remove(ROW_5_VALUE);
+
+        assertFalse("The property handed out for a removed item still reports its former check",
+            rowProperty.get());
+    }
+
+    @Test
     public void testClearChecksOnAnUncheckedModelReportsNoChange() {
         List<String> changes = recordChangesOfCheckedIndices();
 
@@ -835,6 +849,27 @@ public class CheckBitSetModelBaseTest {
         model.check(4);
 
         assertOnlyCheckedIndicesAre();
+    }
+
+    @Test
+    public void testClearingEveryCheckFromTheReportOfACheckReportsCoherentChangesOfTheCheckedItems() {
+        // the checks are reported as two lists, one after the other, and a listener of either of
+        // them is free to change the model from there: whoever rebuilds the checked items from the
+        // changes handed to him has to end up with the items the model holds, whichever of the two
+        // lists the change which reached the model came from
+        model.check(2);
+        List<String> observedCheckedItems = observe(model.getCheckedItems());
+        AtomicInteger reportedChanges = new AtomicInteger();
+        model.getCheckedIndices().addListener((ListChangeListener<Integer>) change -> {
+            if (reportedChanges.getAndIncrement() == 0) {
+                model.clearChecks();
+            }
+        });
+
+        model.check(4);
+
+        assertEquals("The reported changes do not add up to the checked items",
+            Collections.<String>emptyList(), observedCheckedItems);
     }
 
     /**

--- a/controlsfx/src/test/java/org/controlsfx/control/CheckComboBoxTest.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/CheckComboBoxTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2026, ControlsFX
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of ControlsFX, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CONTROLSFX BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.controlsfx.control;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.ComboBox;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests that what a {@link CheckComboBox} renders in its button is the checks held by the check
+ * model the control has.
+ *
+ * <p>The button of the control is a cell of its own, whose text is built from
+ * {@link IndexedCheckModel#getCheckedItems()} and refreshed from a listener of
+ * {@link IndexedCheckModel#getCheckedIndices()}: both are read from the model, and the control
+ * lets an application replace that model through {@link CheckComboBox#setCheckModel(IndexedCheckModel)}.
+ *
+ * <p>The control is therefore shown in a scene of its own, and every assertion goes all the way
+ * down to the text the button renders.
+ */
+public class CheckComboBoxTest extends FxRobot {
+
+    private static final String ITEM_1 = "Item 1";
+    private static final String ITEM_2 = "Item 2";
+    private static final String ITEM_3 = "Item 3";
+
+    private ObservableList<String> items;
+    private CheckComboBox<String> checkComboBox;
+
+    private static final int SCENE_WIDTH = 300;
+    private static final int SCENE_HEIGHT = 200;
+    private static final long LOOKUP_TIMEOUT_MILLIS = 5000;
+
+    @BeforeClass
+    public static void setupSpec() throws TimeoutException {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @After
+    public void afterEach() throws TimeoutException {
+        FxToolkit.cleanupStages();
+    }
+
+    @Test
+    public void testTheButtonRendersTheItemCheckedThroughTheModelOfTheControl() {
+        givenCheckComboBox(ITEM_1, ITEM_2, ITEM_3);
+
+        interact(() -> checkComboBox.getCheckModel().check(ITEM_2));
+
+        assertEquals("The button does not render the checked item", ITEM_2, renderedButtonText());
+    }
+
+    @Test
+    public void testTheButtonRendersTheItemCheckedThroughTheModelTheControlIsGiven() {
+        // setCheckModel(IndexedCheckModel) is public API, and the model the control is given is
+        // the model it has: the checks made through it are the ones the button renders, just as
+        // the checks of the model the control built for itself are.
+        // The replacement is built on a map of its own, as the one the control keeps for its own
+        // model is private to it - which leaves the check boxes of the popup out of this scenario,
+        // the button text being read from the checked items of the model alone.
+        givenCheckComboBox(ITEM_1, ITEM_2, ITEM_3);
+
+        interact(() -> checkComboBox.setCheckModel(
+            new CheckComboBox.CheckComboBoxBitSetCheckModel<>(checkComboBox.getItems(), new HashMap<>())));
+        interact(() -> checkComboBox.getCheckModel().check(ITEM_2));
+
+        assertEquals("The button does not render the checks of the model the control has",
+            ITEM_2, renderedButtonText());
+    }
+
+    /**
+     * Shows a {@link CheckComboBox} holding the given items. The control is put in a scene of its
+     * own, and that scene shown, so that its button is really rendered.
+     */
+    private void givenCheckComboBox(String... itemValues) {
+        items = FXCollections.observableArrayList(itemValues);
+        try {
+            FxToolkit.setupStage(stage -> {
+                checkComboBox = new CheckComboBox<>(items);
+                stage.setScene(new Scene(checkComboBox, SCENE_WIDTH, SCENE_HEIGHT));
+                stage.show();
+                stage.toFront();
+            });
+        } catch (TimeoutException e) {
+            throw new AssertionError("The CheckComboBox could not be shown", e);
+        }
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    /**
+     * Returns the text rendered by the button of the control - what the user actually reads of the
+     * checks that were made.
+     */
+    private String renderedButtonText() {
+        // let the button the checks reached be laid out again before reading what it renders
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ComboBox<?> renderedComboBox = WaitForAsyncUtils.waitForAsyncFx(LOOKUP_TIMEOUT_MILLIS, () -> {
+            for (Node node : checkComboBox.getChildrenUnmodifiable()) {
+                if (node instanceof ComboBox) {
+                    return (ComboBox<?>) node;
+                }
+            }
+            return null;
+        });
+        assertNotNull("Expected the CheckComboBox to be rendered by a ComboBox of its own",
+            renderedComboBox);
+        return WaitForAsyncUtils.waitForAsyncFx(LOOKUP_TIMEOUT_MILLIS,
+            () -> renderedComboBox.getButtonCell().getText());
+    }
+}

--- a/controlsfx/src/test/java/org/controlsfx/control/CheckListViewTest.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/CheckListViewTest.java
@@ -1,0 +1,419 @@
+/**
+ * Copyright (c) 2026, ControlsFX
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of ControlsFX, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CONTROLSFX BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.controlsfx.control;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ListCell;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests that checking items through the check model of a {@link CheckListView} stays consistent
+ * with the {@link BooleanProperty} of each item.
+ *
+ * <p>Both states can drift apart: the check model keeps its own bit set, while the
+ * {@code CheckBoxListCell} of every row is bound to the {@link BooleanProperty} returned by
+ * {@link CheckListView#getItemBooleanProperty(Object)}. Whenever a check reaches the bit set
+ * without updating the matching property, {@code getCheckModel().isChecked(index)} answers
+ * {@code true} while the row is still rendered unchecked.
+ *
+ * <p>The control is therefore shown in a scene of its own, and every assertion goes all the way
+ * down to the CheckBox each row renders.
+ *
+ * <p>Each test below checks items in a specific order, as the defect only shows up for some
+ * sequences. The same scenarios are covered against the check model alone - without going through
+ * the control - by {@link CheckBitSetModelBaseTest}.
+ */
+public class CheckListViewTest extends FxRobot {
+
+    private static final String ITEM_1 = "Item 1";
+    private static final String ITEM_2 = "Item 2";
+    private static final String ITEM_3 = "Item 3";
+    private static final String ITEM_4 = "Item 4";
+    private static final String ITEM_5 = "Item 5";
+
+    private ObservableList<String> items;
+    private CheckListView<String> checkListView;
+
+    private static final int SCENE_WIDTH = 300;
+    private static final int SCENE_HEIGHT = 400;
+    private static final long LOOKUP_TIMEOUT_MILLIS = 5000;
+
+    @BeforeClass
+    public static void setupSpec() throws TimeoutException {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @After
+    public void afterEach() throws TimeoutException {
+        FxToolkit.cleanupStages();
+    }
+
+    @Test
+    public void testCheckFirstItemAfterFollowingItems() {
+        // derived from https://github.com/controlsfx/controlsfx/issues/1549
+        // Checking the first item last does not expose the defect the tests below reproduce, so
+        // this scenario guards against a regression of the original issue.
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4);
+
+        interact(() -> {
+            IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+            checkModel.check(ITEM_2);
+            checkModel.check(ITEM_3);
+            checkModel.check(ITEM_1);
+        });
+
+        assertCheckedIndices(0, 1, 2);
+    }
+
+    @Test
+    public void testCheckItemInsideAlreadyCheckedRange() {
+        // derived from https://github.com/controlsfx/controlsfx/issues/1549#issuecomment-5542131988
+        // "Item 2" closes the gap left in the middle of the checked range
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4);
+
+        interact(() -> {
+            IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+            checkModel.check(ITEM_1);
+            checkModel.check(ITEM_3);
+            checkModel.check(ITEM_4);
+            checkModel.check(ITEM_2);
+        });
+
+        assertCheckedIndices(0, 1, 2, 3);
+    }
+
+    @Test
+    public void testCheckItemAfterCheckingTheSameItemTwice() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where the same item is
+        // checked twice - the second check being a no-op on the check model
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4, ITEM_5);
+
+        interact(() -> {
+            IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+            checkModel.check(ITEM_1);
+            checkModel.check(ITEM_2);
+            checkModel.check(ITEM_2);
+            checkModel.check(ITEM_4);
+        });
+
+        assertCheckedIndices(0, 1, 3);
+    }
+
+    @Test
+    public void testCheckIndicesForItemInsideAlreadyCheckedRange() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 going through
+        // checkIndices(int...) instead of check(T)
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4, ITEM_5);
+
+        interact(() -> {
+            IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+            checkModel.check(ITEM_1);
+            checkModel.check(ITEM_4);
+            checkModel.check(ITEM_5);
+            checkModel.checkIndices(1);
+        });
+
+        assertCheckedIndices(0, 1, 3, 4);
+    }
+
+    @Test
+    public void testCheckItemAfterClearCheckOnUncheckedItem() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where the check of the
+        // unchecked "Item 2" is cleared - a no-op on the model - before "Item 3" is checked
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4, ITEM_5);
+
+        interact(() -> {
+            IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+            checkModel.check(ITEM_1);
+            checkModel.check(ITEM_4);
+            checkModel.check(ITEM_5);
+            checkModel.clearCheck(ITEM_2);
+            checkModel.check(ITEM_3);
+        });
+
+        assertCheckedIndices(0, 2, 3, 4);
+    }
+
+    @Test
+    public void testCheckIndicesNotInAscendingOrder() {
+        // derived from https://github.com/controlsfx/controlsfx/issues/1549
+        // checkIndices(int...) is given the indices of "Item 5" and "Item 1" in descending order
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4, ITEM_5);
+
+        interact(() -> checkListView.getCheckModel().checkIndices(4, 0));
+
+        assertCheckedIndices(0, 4);
+    }
+
+    @Test
+    public void testCheckIndicesWithDuplicateIndex() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where checkIndices(int...)
+        // is given the same index twice
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4, ITEM_5);
+
+        interact(() -> checkListView.getCheckModel().checkIndices(4, 4));
+
+        assertCheckedIndices(4);
+    }
+
+    @Test
+    public void testCheckIndicesAroundAnAlreadyCheckedItem() {
+        // variant of https://github.com/controlsfx/controlsfx/issues/1549 where the items handed to
+        // checkIndices(int...) surround the already checked "Item 3"
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4, ITEM_5);
+
+        interact(() -> {
+            IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+            checkModel.check(ITEM_3);
+            checkModel.checkIndices(0, 4);
+        });
+
+        assertCheckedIndices(0, 2, 4);
+    }
+
+    @Test
+    public void testCheckedItemStaysCheckedAfterAnItemIsAdded() {
+        // adding an item makes the check model follow the change of the item list
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4);
+
+        interact(() -> {
+            checkListView.getCheckModel().check(ITEM_2);
+            items.add(ITEM_5);
+        });
+
+        assertCheckedIndices(1);
+    }
+
+    @Test
+    public void testCheckingAnItemAfterAnItemIsAddedChecksItsCheckBox() {
+        // the CheckBox of an already rendered row stays bound to the property it was given, so
+        // the item has to keep that very property across the change of the item list
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4);
+
+        interact(() -> items.add(ITEM_5));
+        interact(() -> checkListView.getCheckModel().check(ITEM_2));
+
+        assertCheckedIndices(1);
+    }
+
+    @Test
+    public void testReplacingTheItemsAndSettingThemBackKeepsTheChecksMadeAfterwards() {
+        // a control whose list of items is replaced builds a new check model, and the one it
+        // drops has to let go of the list it was built on: both otherwise follow the next change
+        // of that list, the stale one writing the item boolean properties - and through them the
+        // check model the control now holds - back to the checks it still holds itself
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3);
+        ObservableList<String> firstItems = items;
+        ObservableList<String> otherItems = FXCollections.observableArrayList(ITEM_4, ITEM_5);
+
+        interact(() -> checkListView.getCheckModel().check(ITEM_1));
+        interact(() -> checkListView.setItems(otherItems));
+        interact(() -> checkListView.setItems(firstItems));
+        interact(() -> checkListView.getCheckModel().check(ITEM_2));
+        interact(() -> firstItems.add(ITEM_4));
+
+        assertCheckedIndices(1);
+    }
+
+    @Test
+    public void testAStaleCheckModelNoLongerDrivesTheOneTheControlNowHolds() {
+        // getCheckModel() hands out the model the control holds, and an application is free to
+        // keep that reference: a control whose list of items is replaced builds a new model around
+        // the very same item boolean properties, and the one it drops has to let go of them. A
+        // check made through the stale model is rendered by no row, and must therefore not reach
+        // the model the control now holds.
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3);
+        ObservableList<String> firstItems = items;
+        ObservableList<String> otherItems = FXCollections.observableArrayList(ITEM_4, ITEM_5);
+        IndexedCheckModel<String> staleModel = checkListView.getCheckModel();
+
+        interact(() -> checkListView.setItems(otherItems));
+        interact(() -> checkListView.setItems(firstItems));
+        interact(() -> staleModel.check(ITEM_2));
+
+        assertCheckedIndices();
+    }
+
+    @Test
+    public void testTheChecksFollowTheirItemsWhenTheItemListChangesAgainFromTheirReport() {
+        // whoever is told about the reindexed checks is free to change the item list again from
+        // there, and the checks - with the CheckBox rendering each of them - have to follow that
+        // change as they follow any other: a list which is changed again while it is still
+        // reporting hands the check model the range it already followed along with the new one
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4, ITEM_5);
+        AtomicInteger reportedChanges = new AtomicInteger();
+
+        interact(() -> {
+            IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+            checkModel.check(ITEM_2);
+            checkModel.check(ITEM_4);
+            checkModel.getCheckedItems().addListener((ListChangeListener<String>) change -> {
+                if (reportedChanges.getAndIncrement() == 0) {
+                    items.remove(ITEM_5);
+                }
+            });
+            items.remove(ITEM_1);
+        });
+
+        // neither of the removed items was ever checked, so the checks of "Item 2" and "Item 4"
+        // are still theirs - at the positions the two removals leave them at
+        assertCheckedIndices(0, 2);
+    }
+
+    @Test
+    public void testClearingEveryCheckFromTheReportOfACheckUnchecksEveryCheckBox() {
+        // a listener of the checked indices is free to clear the checks from there, which leaves
+        // the change still being reported standing for a check the model no longer holds: each
+        // row renders the check its model ends up with, not that one
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3, ITEM_4, ITEM_5);
+        AtomicInteger reportedChanges = new AtomicInteger();
+
+        interact(() -> {
+            IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+            checkModel.check(ITEM_3);
+            checkModel.getCheckedIndices().addListener((ListChangeListener<Integer>) change -> {
+                if (reportedChanges.getAndIncrement() == 0) {
+                    checkModel.clearChecks();
+                }
+            });
+            checkModel.check(ITEM_5);
+        });
+
+        assertCheckedIndices();
+    }
+
+    /**
+     * Shows a {@link CheckListView} holding the given items. The control is put in a scene of its
+     * own, and that scene shown, so that every row is really rendered: a CheckBox is only bound to
+     * the property of its item once the cell holding it exists.
+     */
+    private void givenCheckListView(String... itemValues) {
+        items = FXCollections.observableArrayList(itemValues);
+        try {
+            FxToolkit.setupStage(stage -> {
+                checkListView = new CheckListView<>(items);
+                stage.setScene(new Scene(checkListView, SCENE_WIDTH, SCENE_HEIGHT));
+                stage.show();
+                stage.toFront();
+            });
+        } catch (TimeoutException e) {
+            throw new AssertionError("The CheckListView could not be shown", e);
+        }
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    /**
+     * Returns the CheckBox rendered by the row of the given index, or {@code null} when that row
+     * holds no cell - which the caller is expected to report rather than to skip over.
+     */
+    private CheckBox renderedCheckBoxOf(int index) {
+        return WaitForAsyncUtils.waitForAsyncFx(LOOKUP_TIMEOUT_MILLIS, () -> {
+            for (Node node : checkListView.lookupAll(".list-cell")) {
+                ListCell<?> cell = (ListCell<?>) node;
+                if (!cell.isEmpty() && cell.getIndex() == index) {
+                    return (CheckBox) cell.getGraphic();
+                }
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Asserts that exactly the given indices are checked - in the check model, in the
+     * {@link BooleanProperty} of every item, and in the CheckBox each row renders, which is what
+     * the user actually sees.
+     */
+    private void assertCheckedIndices(int... expectedCheckedIndices) {
+        // let the rows the checks reached be laid out again before reading what they render
+        WaitForAsyncUtils.waitForFxEvents();
+
+        BitSet expected = new BitSet();
+        for (int index : expectedCheckedIndices) {
+            expected.set(index);
+        }
+
+        IndexedCheckModel<String> checkModel = checkListView.getCheckModel();
+        for (int index = 0; index < items.size(); index++) {
+            String item = items.get(index);
+            String expectedState = expected.get(index) ? "checked" : "not checked";
+
+            assertEquals(
+                MessageFormat.format("Expected the check model to report index {0} ({1}) as {2}",
+                    index, item, expectedState),
+                expected.get(index), checkModel.isChecked(index));
+
+            BooleanProperty itemProperty = checkListView.getItemBooleanProperty(item);
+            assertNotNull(
+                MessageFormat.format("Expected a BooleanProperty for index {0} ({1})", index, item),
+                itemProperty);
+            assertEquals(
+                MessageFormat.format("Expected the BooleanProperty of index {0} ({1}) to be {2}",
+                    index, item, expectedState),
+                expected.get(index), itemProperty.get());
+
+            CheckBox renderedCheckBox = renderedCheckBoxOf(index);
+            assertNotNull(
+                MessageFormat.format("Expected index {0} ({1}) to be rendered by a row of its own",
+                    index, item),
+                renderedCheckBox);
+            assertEquals(
+                MessageFormat.format("Expected the CheckBox of index {0} ({1}) to be rendered as {2}",
+                    index, item, expectedState),
+                expected.get(index), renderedCheckBox.isSelected());
+        }
+
+        List<Integer> expectedIndices = expected.stream().boxed().collect(Collectors.toList());
+        assertEquals("Unexpected checked indices",
+            expectedIndices, new ArrayList<>(checkModel.getCheckedIndices()));
+
+        List<String> expectedItems = expected.stream().mapToObj(items::get).collect(Collectors.toList());
+        assertEquals("Unexpected checked items",
+            expectedItems, new ArrayList<>(checkModel.getCheckedItems()));
+    }
+}

--- a/controlsfx/src/test/java/org/controlsfx/control/CheckListViewTest.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/CheckListViewTest.java
@@ -281,6 +281,22 @@ public class CheckListViewTest extends FxRobot {
     }
 
     @Test
+    public void testTheCheckModelTheControlIsGivenBackGoesOnDrivingTheCheckBoxes() {
+        // setCheckModel(IndexedCheckModel) is public API, and an application is free to take the
+        // model of the control away and to hand it back - the control holds none in between, which
+        // its own key handler already caters for: the model it is given back is the model it has,
+        // and the checks made through it are rendered by the rows holding them
+        givenCheckListView(ITEM_1, ITEM_2, ITEM_3);
+        IndexedCheckModel<String> builtInModel = checkListView.getCheckModel();
+
+        interact(() -> checkListView.setCheckModel(null));
+        interact(() -> checkListView.setCheckModel(builtInModel));
+        interact(() -> checkListView.getCheckModel().check(ITEM_2));
+
+        assertCheckedIndices(1);
+    }
+
+    @Test
     public void testTheChecksFollowTheirItemsWhenTheItemListChangesAgainFromTheirReport() {
         // whoever is told about the reindexed checks is free to change the item list again from
         // there, and the checks - with the CheckBox rendering each of them - have to follow that

--- a/controlsfx/src/test/java/org/controlsfx/control/CheckListViewTest.java
+++ b/controlsfx/src/test/java/org/controlsfx/control/CheckListViewTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -342,6 +343,42 @@ public class CheckListViewTest extends FxRobot {
         });
 
         assertCheckedIndices();
+    }
+
+    @Test
+    public void testTheBooleanPropertyOfACheckedItemIsClearedWhenTheItemListIsReplaced() {
+        // getItemBooleanProperty(T) is public API, handed out to be bound to, and it stands for
+        // the check the control holds on that item: an item which is not in the new list holds no
+        // check any more, so whoever is bound to its property must not go on rendering the one it
+        // had. The same scenario is covered against the check model alone by
+        // CheckBitSetModelBaseTest.
+        givenCheckListView(ITEM_1, ITEM_2);
+        BooleanProperty itemProperty = checkListView.getItemBooleanProperty(ITEM_1);
+
+        interact(() -> checkListView.getCheckModel().check(ITEM_1));
+        interact(() -> checkListView.setItems(FXCollections.observableArrayList(ITEM_3, ITEM_4)));
+
+        assertFalse("The property handed out for an item of the former list still reports its check",
+            itemProperty.get());
+    }
+
+    @Test
+    public void testReplacingTheItemsReportsNoCheckOnTheCheckModelTheControlDrops() {
+        // a control whose list of items is replaced builds a new check model around the very same
+        // item boolean properties: the model it drops has to let go of those properties before the
+        // new one writes them, or the two drive each other through them - and an application which
+        // is still holding the dropped model is told of checks nothing renders any more
+        givenCheckListView(ITEM_1, ITEM_2);
+        IndexedCheckModel<String> droppedModel = checkListView.getCheckModel();
+        interact(() -> droppedModel.check(ITEM_1));
+        AtomicInteger reportedChanges = new AtomicInteger();
+        droppedModel.getCheckedItems().addListener(
+            (ListChangeListener<String>) change -> reportedChanges.incrementAndGet());
+
+        interact(() -> checkListView.setItems(FXCollections.observableArrayList(ITEM_1, ITEM_3)));
+
+        assertEquals("The check model the control dropped still reports changes of its checks",
+            0, reportedChanges.get());
     }
 
     /**


### PR DESCRIPTION
  ## What this fixes

  `CheckListView`, `CheckComboBox` and `CheckTreeView` share `CheckBitSetModelBase`, which holds its
  checks as bits of a `BitSet`. Several defects let that model drift away from what the UI shows:
  `getCheckedIndices()` / `getCheckedItems()` report entries which do not match the ticked boxes, a box
  renders ticked on the wrong row, a check silently disappears, or a listener dies on an
  `IndexOutOfBoundsException`.

  Fixes #1549
  Fixes #1597

  ## The defects

  **1. A stale iteration cache** (the cause of #1549 and #1597) — `BitSetReadOnlyUnbackedObservableList.get(int)`
  caches the last resolved `(position, value)` pair to keep a sequential walk cheap (RT-39776). That pair
  only stays valid as long as the `BitSet` is left untouched, but `check()`, `checkIndices()`,
  `clearCheck()` and `clearChecks()` mutated the `BitSet` directly, behind the list's back. The following
  lookups resumed from an invalid pair and answered a wrong index — visible when a check closes a gap in
  an already checked range, or when the same index is checked twice.

  The list now owns the `BitSet`: no other handle on it remains, the model reads and mutates it through
  the list, and every mutator drops the cached pair. The invalidation can no longer be bypassed.

  **2. The cache left in an exhausted state** — `get(int)` answers `-1` for a position beyond the checked
  count, and used to leave the cached pair pointing at that exhausted state. The forward and backward
  short circuits cannot tell it apart from a resolved one, so the next lookup was computed from it and
  returned a wrong index: reading one index too far corrupted the reads which followed. `get(int)` now
  caches a pair only when it resolved one, and resumes its forward walk from that pair instead of
  counting from the first bit again at every range boundary.

  **3. `checkIndices(int...)` reported its arguments rather than its effect** — it set every given bit and
  then reported the whole argument array as added, without ever looking at it. Out-of-range indices were
  let through where `check(int)` rejects them, an already checked index was reported as added a second
  time, and duplicate or unsorted arguments broke the range change, which walks the reported indices
  assuming they are distinct and ascending. It now reduces the arguments to the indices it actually adds,
  and reports them as one range per run of consecutive indices — so the `splitChanges` parameter and the
  branch reporting a single range spanning unrelated positions are gone.

  **4. No-op calls reported a change** — `check(int)` on an already checked index, `clearCheck(int)` on an
  unchecked one and `clearChecks()` on an empty model each fired a change describing nothing
  (`clearCheck()` looked up a position for an index the list never held). They return early now.

  **5. `isChecked(int)` threw on an index outside the list** — it reached straight into the `BitSet`, so it
  threw `IndexOutOfBoundsException` on the `-1` that `getItemIndex(T)` answers for an item the list does
  not hold; both `isChecked(T)` and `toggleCheckState(T)` hand that `-1` straight over. It answers `false`
  outside the list now, the way `check(int)` and `clearCheck(int)` already ignore such an index.

  **6. Checks did not follow their items when the item list changed** — `updateMap()` rebuilds the
  `BooleanProperty` of every item but left the `BitSet` untouched, so a check stayed on a *position*
  rather than on the item it was made on. Removing a checked item left its bit behind, out of the bounds
  of the list or picked up by whichever item landed on that index — which then showed up checked although
  it never was; `clearChecks()` then mapped that stale index back to an item and threw
  `IndexOutOfBoundsException` inside a listener, where JavaFX only hands the failure over to the uncaught
  exception handler of the thread. And because the rebuild replaces the map rather than the checked
  indices, no listener fired to close the gap: the box of an item the model still reported as checked
  rendered unchecked.

  `updateMap()` now reads the checked items from the `BooleanProperty` of each item — an index is stale as
  soon as the list of items changes, while a property stays with the item it was created for — and
  rebuilds both the checked indices and the properties from them. An item the changed list still holds
  keeps its check, wherever it landed; a check made on an item which is gone dies with it.

  **7. `checkAll()` fired a change per item** — it hands every index over in a single call now, reported as
  one change.

  **8. The added-range change overrode `getAddedSize()`** — the override answered `to - from` without the
  state check its `getFrom()` and `getTo()` make, so an inspection made before `next()` read `0` where
  every other one throws `IllegalStateException`. The base implementation computes the same size through
  those two accessors, so the override is dropped.

  ## Behaviour visible to callers

  - No change event is fired for a call which changes nothing.
  - `checkIndices(int...)` ignores out-of-range indices instead of setting them (`BitSet.set(-1)` threw),
    and reports only the indices it adds.
  - `isChecked(int)` answers `false` outside the list instead of throwing.
  - Checks follow their items across a change of the item list, instead of staying on the positions they
    were made at.

  ## Tests

  `./gradlew :controlsfx:test` — the whole controlsfx suite passes (85 tests, no failure).

  - `CheckBitSetModelBaseTest`: 14 → 33 tests, covering the check orders of #1549 and #1597, the reads
    beyond the checked count, the invalid and duplicate indices, the no-op calls and the item list
    changes.
  - `CheckListViewTest`: new, 9 tests driving a real `CheckListView` and asserting on the
    `BooleanProperty` the `CheckBox` of each row is bound to — the same scenarios, seen from the control.

  The commits are meant to be read in order: each one states the defect it repairs and the reasoning
  behind the fix